### PR TITLE
Fix bug in query serialization for DBQuery.all, was trying to serialize ...

### DIFF
--- a/src/main/java/org/mongojack/DBQuery.java
+++ b/src/main/java/org/mongojack/DBQuery.java
@@ -426,7 +426,7 @@ public class DBQuery {
          * @return the query
          */
         public Q all(String field, Collection<?> values) {
-            return put(field, QueryOperators.ALL, values);
+            return put(field, QueryOperators.ALL, new SimpleQueryCondition(values));
         }
 
         /**
@@ -437,7 +437,7 @@ public class DBQuery {
          * @return the query
          */
         public Q all(String field, Object... values) {
-            return put(field, QueryOperators.ALL, Arrays.asList(values));
+            return all (field, Arrays.asList(values));
         }
 
         /**

--- a/src/test/java/org/mongojack/TestQuerySerialization.java
+++ b/src/test/java/org/mongojack/TestQuerySerialization.java
@@ -63,6 +63,18 @@ public class TestQuerySerialization extends MongoDBTestBase {
         assertThat(coll.find().and(DBQuery.lessThan("i", 12), DBQuery.greaterThan("i", 4)).toArray(), hasSize(1));
         assertThat(coll.find().and(DBQuery.lessThan("i", 12), DBQuery.greaterThan("i", 9)).toArray(), hasSize(0));
     }
+    
+    @Test
+    public void testAll() {
+        MockObject o = new MockObject();
+        MockObject o1 = new MockObject();
+        o1.id = new org.bson.types.ObjectId().toString();
+        o.items = Arrays.asList(o1);
+        coll.save(o);
+        
+        // Ensure that the serializer actually worked
+        assertThat(coll.find().all("items", o1).toArray(), hasSize(1));
+    }
 
     @Test
     public void testList() {


### PR DESCRIPTION
...each passed in object as Collection<T> instead of T
