### PR TITLE
Feature/upgrade jackson and bson4jackson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 target
-
+.idea
 .project
 .classpath
 .settings

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -66,9 +67,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-           <groupId>org.mockito</groupId>
-           <artifactId>mockito-all</artifactId>
-           <version>1.9.5</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -263,7 +264,7 @@
                 <role>developer</role>
             </roles>
             <organization>MongoDB, Inc.</organization>
-        </contributor>        
+        </contributor>
         <contributor>
             <name>Christopher Exell</name>
             <url>https://github.com/exell-christopher</url>

--- a/src/main/java/org/mongojack/internal/MongoAnnotationIntrospector.java
+++ b/src/main/java/org/mongojack/internal/MongoAnnotationIntrospector.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.PropertyName;
 
 /**
  * Annotation introspector that supports @ObjectId's
- * 
+ *
  * @author James Roper
  * @since 1.0
  */

--- a/src/main/java/org/mongojack/internal/object/BsonObjectGenerator.java
+++ b/src/main/java/org/mongojack/internal/object/BsonObjectGenerator.java
@@ -16,11 +16,6 @@
  */
 package org.mongojack.internal.object;
 
-import com.fasterxml.jackson.core.*;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
-import org.mongojack.internal.util.VersionUtils;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -28,9 +23,25 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.mongojack.internal.util.VersionUtils;
+
+import com.fasterxml.jackson.core.Base64Variant;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonStreamContext;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.Version;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
 /**
  * JSON generator that actually generates a BSON object
- * 
+ *
  * @author James Roper
  * @since 1.0
  */
@@ -453,13 +464,11 @@ public class BsonObjectGenerator extends JsonGenerator {
             object = new BasicDBObject();
         }
 
-        @Override
-        void set(Object value) {
+        @Override void set(Object value) {
             object.put(getCurrentName(), value);
         }
 
-        @Override
-        DBObject get() {
+        @Override DBObject get() {
             return object;
         }
     }
@@ -474,13 +483,11 @@ public class BsonObjectGenerator extends JsonGenerator {
             super(parent, JsonStreamContext.TYPE_ARRAY);
         }
 
-        @Override
-        void set(Object value) {
+        @Override void set(Object value) {
             array.add(value);
         }
 
-        @Override
-        List<Object> get() {
+        @Override List<Object> get() {
             return array;
         }
     }
@@ -497,14 +504,12 @@ public class BsonObjectGenerator extends JsonGenerator {
             this.rootValue = rootValue;
         }
 
-        @Override
-        void set(Object value) {
+        @Override void set(Object value) {
             throw new IllegalStateException(
                     "Cannot write multiple values to a root value node");
         }
 
-        @Override
-        Object get() {
+        @Override Object get() {
             return rootValue;
         }
     }


### PR DESCRIPTION
See: https://github.com/devbliss/mongojack/issues/48 

Upgrading dependencies for Jackson to 2.3.2 and Bson4Jackson to 2.3.1. Changes are covered by existing tests and all tests have passed. 

The main motivation behind this upgrade is to prevent potential conflicts with Jackson 2.2.X when using frameworks which require Jackson 2.3.X, such as Dropwizard. Thanks!
