### PR TITLE
Fluent Aggregation Builder

### DIFF
--- a/src/main/java/org/mongojack/Aggregation.java
+++ b/src/main/java/org/mongojack/Aggregation.java
@@ -59,6 +59,5 @@ public class Aggregation<T> {
         allOps.add(initialOp);
         allOps.addAll(Arrays.asList(additionalOps));
         return allOps;
-
     }
 }

--- a/src/main/java/org/mongojack/aggregation/AggregatePipelineOperation.java
+++ b/src/main/java/org/mongojack/aggregation/AggregatePipelineOperation.java
@@ -1,0 +1,15 @@
+package org.mongojack.aggregation;
+
+import com.mongodb.DBObject;
+
+/**
+ * Root class of all aggregation pipeline operations
+ */
+public abstract class AggregatePipelineOperation {
+
+    protected String dollar(String input) {
+        return "$" + input;
+    }
+
+    public abstract DBObject apply();
+}

--- a/src/main/java/org/mongojack/aggregation/AggregationBuilder.java
+++ b/src/main/java/org/mongojack/aggregation/AggregationBuilder.java
@@ -1,0 +1,141 @@
+package org.mongojack.aggregation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mongojack.Aggregation;
+
+import com.mongodb.DBObject;
+
+/**
+ * The AggregationBuilder provides a fluent builder for creating mongo aggergation queries.
+ * It works in conjunction with sub-builders that implement fluent builders for each of the
+ * aggregation pipeline operations (match, group, project, sort, unwind)
+ * 
+ * This class is an attempt to simplify the usage of the mongojack
+ * Aggregation feature which raps native Mongo Java Driver's aggergation.
+ * 
+ * See the mongodocs for how aggregation pipelines work
+ * 
+ * @see <a href="http://docs.mongodb.org/manual/core/aggregation-pipeline/">Aggregation Pipeline</a>
+ * 
+ * @param <T> The type of aggregation result object
+ */
+public class AggregationBuilder<T> {
+
+    private final List<AggregatePipelineOperation> pipeline;
+
+    public AggregationBuilder() {
+        pipeline = new ArrayList<AggregatePipelineOperation>();
+    }
+
+    /**
+     * Adds a match operation to the pipeline
+     * 
+     * @see MatchAggregation
+     * 
+     * @param match the Match operation
+     * @return the builder
+     */
+    public AggregationBuilder<T> match(MatchAggregation match) {
+        pipeline.add(match);
+        return this;
+    }
+
+    /**
+     * Adds an unwind operation to the pipeline
+     * 
+     * @see UnwindAggregation
+     * 
+     * @param unwind the Unwind operation
+     * @return the builder
+     */
+    public AggregationBuilder<T> unwind(UnwindAggregation unwind) {
+        pipeline.add(unwind);
+        return this;
+    }
+
+    /**
+     * Adds a group operation to the pipeline
+     * 
+     * @see GroupAggregation
+     * 
+     * @param group the Group operation
+     * @return the builder
+     */
+    public AggregationBuilder<T> group(GroupAggregation group) {
+        pipeline.add(group);
+        return this;
+    }
+
+    /**
+     * Adds a project operation to the pipeline
+     * 
+     * @see ProjectAggregation
+     * 
+     * @param project the Project operation
+     * @return the builder
+     */
+    public AggregationBuilder<T> project(ProjectAggregation project) {
+        pipeline.add(project);
+        return this;
+    }
+
+    /**
+     * Adds a sort operation to the pipeline
+     * 
+     * @see SortAggregation
+     * 
+     * @param sort the Sort operation
+     * @return the builder
+     */
+    public AggregationBuilder<T> sort(SortAggregation sort) {
+        pipeline.add(sort);
+        return this;
+    }
+
+    /**
+     * Adds a limit operation to the pipeline
+     * 
+     * @see LimitAggregation
+     * 
+     * @param limit the Limit operation
+     * @return the builder
+     */
+    public AggregationBuilder<T> limit(LimitAggregation limit) {
+        pipeline.add(limit);
+        return this;
+    }
+
+    /**
+     * Build the query. The
+     * 
+     * @param resultType The class of type T for which we create the typed Aggregation
+     * @see org.mongojack.Aggregation
+     * @return the typed aggregation query which can be passed to collection.aggregate()
+     */
+    public Aggregation<T> build(Class<T> resultType) {
+        DBObject initialOp;
+        DBObject[] additionalOpsArray;
+        List<DBObject> additionalOpsList = new ArrayList<DBObject>();
+
+        initialOp = pipeline.remove(0).apply();
+
+        for (AggregatePipelineOperation op : pipeline) {
+            additionalOpsList.add(op.apply());
+        }
+
+        additionalOpsArray = additionalOpsList.toArray(new DBObject[0]);
+        return new Aggregation<T>(resultType, initialOp, additionalOpsArray);
+    }
+
+    @Override
+    public String toString() {
+        String output = "";
+        for (AggregatePipelineOperation operation : pipeline) {
+            output += operation + "\n";
+        }
+        return output;
+    }
+
+}

--- a/src/main/java/org/mongojack/aggregation/GroupAggregation.java
+++ b/src/main/java/org/mongojack/aggregation/GroupAggregation.java
@@ -1,0 +1,147 @@
+package org.mongojack.aggregation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Fluent builder for the mongo Group aggregation pipeline operation
+ * 
+ * @see <a href="http://docs.mongodb.org/manual/reference/operator/aggregation/group/#pipe._S_group">Mongo Aggregation -
+ *      Group</a>
+ */
+public class GroupAggregation extends AggregatePipelineOperation {
+
+    private DBObject group;
+
+    /**
+     * "Group-By" multiple fields
+     * 
+     * @param field the first field in the group-by
+     * @param moreFields the other fields
+     */
+    public GroupAggregation(String field, String... moreFields) {
+        DBObject groupFields;
+
+        List<String> fieldList = new ArrayList<String>();
+        fieldList.add(field);
+
+        if (moreFields != null)
+            fieldList.addAll(Arrays.asList(moreFields));
+
+        if (fieldList.size() == 1) {
+            groupFields = new BasicDBObject("_id", dollar(field));
+        } else {
+            BasicDBObject groupFieldList = new BasicDBObject();
+
+            for (String groupByfield : fieldList) {
+                groupFieldList.put(groupByfield, dollar(groupByfield));
+            }
+            groupFields = new BasicDBObject("_id", groupFieldList);
+        }
+        this.group = new BasicDBObject("$group", groupFields);
+    }
+
+    /**
+     * "Group-By" a single field
+     * 
+     * @param field The field to group by
+     */
+    public GroupAggregation(String field) {
+        this(field, (String[]) null);
+    }
+
+    /**
+     * Group by an empty doc. Useful for counting everything
+     */
+    public GroupAggregation() {
+        this.group = new BasicDBObject("$group", new BasicDBObject("_id", new BasicDBObject()));
+    }
+
+    /**
+     * Add a sum operation to the grouping.
+     * 
+     * @param alias The name of the newly created sum field
+     * @param fieldName The field in the original doc we wish to sum
+     * @return the builder
+     */
+    public GroupAggregation withSum(String alias, String fieldName) {
+        return withGroupAccumulator("$sum", alias, fieldName);
+    }
+
+    /**
+     * Add an average operation to the grouping.
+     * 
+     * @param alias The name of the newly created average field
+     * @param fieldName The field in the original doc we wish to average
+     * @return the builder
+     */
+    public GroupAggregation withAvg(String alias, String fieldName) {
+        return withGroupAccumulator("$avg", alias, fieldName);
+    }
+
+    /**
+     * Add a min operation to the grouping.
+     * 
+     * @param alias The name of the newly created min field
+     * @param fieldName The field in the original doc we wish find the min of
+     * @return the builder
+     */
+    public GroupAggregation withMin(String alias, String fieldName) {
+        return withGroupAccumulator("$min", alias, fieldName);
+    }
+
+    /**
+     * Add a max operation to the grouping.
+     * 
+     * @param alias The name of the newly created max field
+     * @param fieldName The field in the original doc we wish find the max of
+     * @return the builder
+     */
+    public GroupAggregation withMax(String alias, String fieldName) {
+        return withGroupAccumulator("$max", alias, fieldName);
+    }
+
+    private GroupAggregation withGroupAccumulator(String accumulator, String alias, String fieldName) {
+
+        ((BasicDBObject) group.get("$group")).append(alias, new BasicDBObject(accumulator, dollar(fieldName)));
+
+        return this;
+    }
+
+    /**
+     * Add an document count operation to the grouping
+     * 
+     * @param alias The name of the newly created counter field
+     * @return the builder
+     */
+    public GroupAggregation withCount(String alias) {
+        ((BasicDBObject) group.get("$group")).append(alias, new BasicDBObject("$sum", 1));
+        return this;
+    }
+
+    /**
+     * Add the operation $addToSet to the grouping.
+     * 
+     * @param alias new name of field for array
+     * @param fieldName in original document
+     * @return the builder
+     */
+    public GroupAggregation withUniqueList(String alias, String fieldName) {
+        return withGroupAccumulator("$addToSet", alias, fieldName);
+    }
+
+    @Override
+    public String toString() {
+        return group.toString();
+    }
+
+    @Override
+    public DBObject apply() {
+        return group;
+    }
+
+}

--- a/src/main/java/org/mongojack/aggregation/LimitAggregation.java
+++ b/src/main/java/org/mongojack/aggregation/LimitAggregation.java
@@ -1,0 +1,28 @@
+package org.mongojack.aggregation;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Fluent builder for the mongo Limit aggregation pipeline operation
+ * 
+ * @see <a href="http://docs.mongodb.org/manual/reference/operator/aggregation/limit/">Mongo Aggregation - Limit</a>
+ */
+public class LimitAggregation extends AggregatePipelineOperation {
+
+    private DBObject limit;
+
+    public LimitAggregation(int limitNumber) {
+        limit = new BasicDBObject("$limit", limitNumber);
+    }
+
+    @Override
+    public DBObject apply() {
+        return limit;
+    }
+
+    @Override
+    public String toString() {
+        return limit.toString();
+    }
+}

--- a/src/main/java/org/mongojack/aggregation/MatchAggregation.java
+++ b/src/main/java/org/mongojack/aggregation/MatchAggregation.java
@@ -1,0 +1,329 @@
+package org.mongojack.aggregation;
+
+import java.util.List;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Fluent builder for the mongo Match aggregation pipeline operation
+ * 
+ * @see <a href="http://docs.mongodb.org/manual/reference/operator/aggregation/match/#pipe._S_match">Mongo Aggregation -
+ *      Match</a>
+ */
+public class MatchAggregation extends AggregatePipelineOperation {
+
+    private DBObject match;
+
+    /**
+     * Create a new, empty match operation
+     */
+    public MatchAggregation() {
+        match = new BasicDBObject("$match", new BasicDBObject());
+    }
+
+    /**
+     * Create a new match operation matching on a field:value
+     * 
+     * @param field The field in the doc
+     * @param value The value we want to match against
+     */
+    public MatchAggregation(String field, Object value) {
+        match = new BasicDBObject("$match", new BasicDBObject(field, value));
+    }
+
+    /**
+     * 
+     * Add a match on field:value
+     * 
+     * @param field The field in the doc
+     * @param value The value we want to match against
+     * @return the builder
+     */
+    public MatchAggregation on(String field, Object value) {
+
+        ((BasicDBObject) match.get("$match")).append(field, value);
+
+        return this;
+    }
+
+    /**
+     * Add an $exists check to the match
+     * 
+     * @param field The field we check for existance
+     * @return the builder
+     */
+    public MatchAggregation exits(String field) {
+
+        ((BasicDBObject) match.get("$match")).append(field, new BasicDBObject("$exists", true));
+
+        return this;
+    }
+
+    /**
+     * Add an NOT $exists check to the match
+     * 
+     * @param field The field we check for non-existance
+     * @return the builder
+     */
+    public MatchAggregation notExits(String field) {
+
+        ((BasicDBObject) match.get("$match")).append(field, new BasicDBObject("$exists", false));
+
+        return this;
+    }
+
+    /**
+     * Adds a greater than condition to the match
+     * 
+     * @param field the field in the doc we are comparing
+     * @param value the value we are comparing against
+     * @return the builder
+     */
+    public MatchAggregation greaterThan(String field, Object value) {
+        return unaryComparison(field, "$gt", value);
+    }
+
+    /**
+     * Adds a less than condition to the match
+     * 
+     * @param field the field in the doc we are comparing
+     * @param value the value we are comparing against
+     * @return the builder
+     */
+    public MatchAggregation lessThan(String field, Object value) {
+        return unaryComparison(field, "$lt", value);
+    }
+
+    /**
+     * Adds a greater than or equal to condition to the match
+     * 
+     * @param field the field in the doc we are comparing
+     * @param value the value we are comparing against
+     * @return the builder
+     */
+    public MatchAggregation greaterThanEqual(String field, Object value) {
+        return unaryComparison(field, "$gte", value);
+    }
+
+    /**
+     * Adds a less than or equal to condition to the match
+     * 
+     * @param field the field in the doc we are comparing
+     * @param value the value we are comparing against
+     * @return the builder
+     */
+    public MatchAggregation lessThanEqual(String field, Object value) {
+        return unaryComparison(field, "$lte", value);
+    }
+
+    private MatchAggregation unaryComparison(String field, String operator, Object value) {
+        ((BasicDBObject) match.get("$match")).append(field, new BasicDBObject(operator, value));
+        return this;
+    }
+
+    /**
+     * Add a two value comparison to the match
+     * 
+     * eg. greaterThanOrLessThan(x,A,B) = A < x || x < B
+     * 
+     * @param field the field in the doc we are comparing
+     * @param greaterThanValue check to see if the field is > this value
+     * @param lessThanValue check to see if the field is < this value
+     * @return
+     */
+    public MatchAggregation greaterThanOrLessThan(String field, Object greaterThanValue, Object lessThanValue) {
+        BasicDBList list = new BasicDBList();
+        list.add(new BasicDBObject(field, new BasicDBObject("$gt", greaterThanValue)));
+        list.add(new BasicDBObject(field, new BasicDBObject("$lt", lessThanValue)));
+        ((BasicDBObject) match.get("$match")).append("$or", list);
+        return this;
+    }
+
+    /**
+     * Add a two value comparison to the match
+     * 
+     * eg. greaterThanEqualOrLessThanEqual(x,A,B) = A <= x || x <= B
+     * 
+     * @param field the field in the doc we are comparing
+     * @param greaterThanValue check to see if the field is >= this value
+     * @param lessThanValue check to see if the field is <= this value
+     * @return
+     */
+    public MatchAggregation greaterThanEqualOrLessThanEqual(String field, Object greaterThanValue, Object lessThanValue) {
+        BasicDBList list = new BasicDBList();
+        list.add(new BasicDBObject(field, new BasicDBObject("$gte", greaterThanValue)));
+        list.add(new BasicDBObject(field, new BasicDBObject("$lte", lessThanValue)));
+        ((BasicDBObject) match.get("$match")).append("$or", list);
+        return this;
+    }
+
+    /**
+     * Add a two value comparison to the match
+     * 
+     * eg. greaterThanAndLessThan(x,A,B) = A < x < B
+     * 
+     * @param field the field in the doc we are comparing
+     * @param greaterThanValue check to see if the field is > this value
+     * @param lessThanValue check to see if the field is < this value
+     * @return
+     */
+    public MatchAggregation greaterThanAndLessThan(String field, Object greaterThanValue, Object lessThanValue) {
+        return binaryComparison(field, "$gt", greaterThanValue, "$lt", lessThanValue);
+    }
+
+    /**
+     * Add a two value comparison to the match
+     * 
+     * eg. greaterThanEqualAndLessThanEqual(x,A,B) : A <= x <= B
+     * 
+     * @param field the field in the doc we are comparing
+     * @param greaterThanValue check to see if the field is >= this value
+     * @param lessThanValue check to see if the field is <= this value
+     * @return
+     */
+    public MatchAggregation greaterThanEqualAndLessThanEqual(String field, Object greaterThanValue, Object lessThanValue) {
+        return binaryComparison(field, "$gte", greaterThanValue, "$lte", lessThanValue);
+    }
+
+    /**
+     * Add a two value comparison to the match
+     * 
+     * eg. greaterThanEqualAndLessThanEqual(x,A,B) : A < x <= B
+     * 
+     * @param field the field in the doc we are comparing
+     * @param greaterThanValue check to see if the field is > this value
+     * @param lessThanValue check to see if the field is <= this value
+     * @return
+     */
+    public MatchAggregation greaterThanAndLessThanEqual(String field, Object greaterThanValue, Object lessThanValue) {
+        return binaryComparison(field, "$gt", greaterThanValue, "$lte", lessThanValue);
+    }
+
+    /**
+     * Add a two value comparison to the match
+     * 
+     * eg. greaterThanEqualAndLessThan(x,A,B) : A <= x < B
+     * 
+     * @param field the field in the doc we are comparing
+     * @param greaterThanValue check to see if the field is >= this value
+     * @param lessThanValue check to see if the field is < this value
+     * @return
+     */
+    public MatchAggregation greaterThanEqualAndLessThan(String field, Object greaterThanValue, Object lessThanValue) {
+        return binaryComparison(field, "$gte", greaterThanValue, "$lt", lessThanValue);
+    }
+
+    private MatchAggregation binaryComparison(String field, String operator1, Object value1, String operator2, Object value2) {
+        ((BasicDBObject) match.get("$match")).append(field, new BasicDBObject(operator1, value1).append(operator2, value2));
+        return this;
+    }
+
+    /**
+     * Add match criteria to check the field is not an empty object
+     * Uses not-in operator. eg. field_name:{$nin:[{}]}
+     * 
+     * @param field The field we match as an non-empty object
+     * @return the builder
+     */
+    public MatchAggregation notEmptyObject(String field) {
+        BasicDBList listWithEmptyObject = new BasicDBList();
+        listWithEmptyObject.add(new BasicDBObject());
+        ((BasicDBObject) match.get("$match")).append(field, new BasicDBObject("$nin", listWithEmptyObject));
+
+        return this;
+    }
+
+    /**
+     * Add match criteria to check the field is an empty object
+     * 
+     * @param field The field we match as an empty object
+     * @return the builder
+     */
+    public MatchAggregation emptyObject(String field) {
+        BasicDBList listWithEmptyObject = new BasicDBList();
+        listWithEmptyObject.add(new BasicDBObject());
+        ((BasicDBObject) match.get("$match")).append(field, new BasicDBObject());
+
+        return this;
+    }
+
+    /**
+     * Add match criteria to check the field is one of a set of given values
+     * Uses $in (in) operator. eg. field_name:{$in:["X", "Y", "Z"]}
+     * 
+     * @param field The field we match as an non-empty object
+     * @return the builder
+     */
+    public MatchAggregation in(String field, String... values) {
+        return arrayMatch("$in", field, values);
+    }
+
+    /**
+     * Add match criteria to check the field is NOT one of a set of given values
+     * Uses $nin (not-in) operator. eg. field_name:{$in:["X", "Y", "Z"]}
+     * 
+     * @param field The field we match as an non-empty object
+     * @return the builder
+     */
+    public MatchAggregation nin(String field, String... values) {
+
+        return arrayMatch("$nin", field, values);
+    }
+
+    private MatchAggregation arrayMatch(String inOrNotInOperator, String field, String... values) {
+        BasicDBList matchArray = new BasicDBList();
+        for (int i = 0; i < values.length; i++) {
+            matchArray.add(values[i]);
+        }
+        ((BasicDBObject) match.get("$match")).append(field, new BasicDBObject(inOrNotInOperator, matchArray));
+
+        return this;
+    }
+
+    /**
+     * Add match condition that field value is one of the values in list.
+     * e.g. {field: {$in: [x, y, z]}}
+     * 
+     * @param field
+     * @param values
+     * @return the builder
+     */
+    public MatchAggregation inList(String field, List<String> values) {
+        return listMatch("$in", field, values);
+    }
+
+    /**
+     * Add match condition that field value is not one of the values in list.
+     * e.g. {field: {$nin: [x, y, z]}}
+     * 
+     * @param field
+     * @param values
+     * @return the builder
+     */
+    public MatchAggregation notInList(String field, List<String> values) {
+        return listMatch("$nin", field, values);
+    }
+
+    private MatchAggregation listMatch(String operator, String field, List<String> values) {
+        if (values != null) {
+            BasicDBList matchArray = new BasicDBList();
+            for (String s : values) {
+                matchArray.add(s);
+            }
+            ((BasicDBObject) match.get("$match")).append(field, new BasicDBObject(operator, matchArray));
+        }
+        return this;
+    }
+
+    @Override
+    public DBObject apply() {
+        return match;
+    }
+
+    @Override
+    public String toString() {
+        return match.toString();
+    }
+}

--- a/src/main/java/org/mongojack/aggregation/ProjectAggregation.java
+++ b/src/main/java/org/mongojack/aggregation/ProjectAggregation.java
@@ -1,0 +1,169 @@
+package org.mongojack.aggregation;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Fluent builder for the mongo Project aggregation pipeline operation
+ * 
+ * @see <a href="http://docs.mongodb.org/manual/reference/operator/aggregation/project/">Mongo Aggregation - Project</a>
+ */
+public class ProjectAggregation extends AggregatePipelineOperation {
+
+    private DBObject project;
+    private String parentKey = "$project";
+
+    /**
+     * Create a new projection operation and add a field mapping
+     * 
+     * @param inputField
+     * @param outputField
+     */
+    public ProjectAggregation(String inputField, String outputField) {
+        project = new BasicDBObject(parentKey, new BasicDBObject(outputField, dollar(inputField)));
+
+    }
+
+    /**
+     * Create a new, empty projection operation
+     */
+    public ProjectAggregation() {
+        project = new BasicDBObject("$project", new BasicDBObject());
+
+    }
+
+    /**
+     * Create a new projection for a nested document
+     * 
+     * @param childName the field underwhich to created the new nested document
+     */
+    public ProjectAggregation(String childName) {
+        project = new BasicDBObject();
+        this.parentKey = childName;
+    }
+
+    /**
+     * Set a new field mapping for the projection
+     * 
+     * @param inputField
+     * @param outputField
+     * @return the builder
+     */
+    public ProjectAggregation set(String inputField, String outputField) {
+
+        BasicDBObject target = (BasicDBObject) project.get(parentKey);
+        if (target == null)
+            target = (BasicDBObject) project;
+
+        target.append(outputField, dollar(inputField));
+
+        return this;
+    }
+
+    /**
+     * Set a new field mapping for the projection using the same key for the
+     * input and output fields.
+     * 
+     * @param inputAndOutputField
+     * @return the builder
+     */
+    public ProjectAggregation set(String inputAndOutputField) {
+
+        BasicDBObject target = (BasicDBObject) project.get(parentKey);
+        if (target == null)
+            target = (BasicDBObject) project;
+
+        target.append(inputAndOutputField, dollar(inputAndOutputField));
+
+        return this;
+    }
+
+    /**
+     * Remove the _id from the doc
+     * 
+     * @return the builder
+     */
+    public ProjectAggregation supressID() {
+
+        BasicDBObject target = (BasicDBObject) project.get(parentKey);
+        if (target == null)
+            target = (BasicDBObject) project;
+
+        target.append("_id", 0);
+
+        return this;
+    }
+
+    /**
+     * Sets the _id for the doc
+     * 
+     * @param inputField the _id to this field
+     * @return the builder
+     */
+    public ProjectAggregation setId(String inputField) {
+
+        BasicDBObject target = (BasicDBObject) project.get(parentKey);
+        if (target == null)
+            target = (BasicDBObject) project;
+
+        target.append(inputField, "$_id");
+
+        return this;
+    }
+
+    /**
+     * Project into a nested document
+     * 
+     * @param nestedChild the nested projection
+     * @return the builder
+     */
+    public ProjectAggregation into(ProjectAggregation nestedChild) {
+
+        BasicDBObject target = (BasicDBObject) project.get(parentKey);
+        if (target == null)
+            target = (BasicDBObject) project;
+
+        target.append(nestedChild.parentKey, nestedChild.apply());
+
+        return this;
+    }
+
+    /**
+     * Computes the sum of a list of fields
+     * 
+     * @param outputfield the new field that contains the result
+     * @param operands
+     * @return the builder
+     */
+    public ProjectAggregation add(String outputfield, String... operands) {
+        return projectOperation("$add", outputfield, operands);
+    }
+
+    private ProjectAggregation projectOperation(String operator, String outputfield, String... operands) {
+
+        BasicDBList inputFieldList = new BasicDBList();
+        for (int i = 0; i < operands.length; i++) {
+            inputFieldList.add(dollar(operands[i]));
+        }
+
+        BasicDBObject target = (BasicDBObject) project.get(parentKey);
+        if (target == null)
+            target = (BasicDBObject) project;
+
+        target.append(outputfield, new BasicDBObject(operator, inputFieldList));
+
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return project.toString();
+    }
+
+    @Override
+    public DBObject apply() {
+        return project;
+    }
+
+}

--- a/src/main/java/org/mongojack/aggregation/SortAggregation.java
+++ b/src/main/java/org/mongojack/aggregation/SortAggregation.java
@@ -1,0 +1,57 @@
+package org.mongojack.aggregation;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Fluent builder for the mongo Sort aggregation pipeline operation
+ * 
+ * @see <a href="http://docs.mongodb.org/manual/reference/operator/aggregation/sort/">Mongo Aggregation - Sort</a>
+ */
+public class SortAggregation extends AggregatePipelineOperation {
+
+    private DBObject sort;
+
+    public SortAggregation() {
+        sort = new BasicDBObject("$sort", new BasicDBObject());
+    }
+
+    /**
+     * Sort ascending
+     * 
+     * @param field the field to sort by
+     * @return the builder
+     */
+    public SortAggregation ascending(String field) {
+        return sortOrder(field, 1);
+    }
+
+    /**
+     * Sort descending
+     * 
+     * @param field the field to sort by
+     * @return the builder
+     */
+    public SortAggregation descending(String field) {
+        return sortOrder(field, -1);
+    }
+
+    /**
+     * @param field
+     * @param order -1 for descening and 1 for asending
+     */
+    private SortAggregation sortOrder(String field, int order) {
+        ((BasicDBObject) sort.get("$sort")).append(field, order);
+        return this;
+    }
+
+    @Override
+    public DBObject apply() {
+        return sort;
+    }
+
+    @Override
+    public String toString() {
+        return sort.toString();
+    }
+}

--- a/src/main/java/org/mongojack/aggregation/UnwindAggregation.java
+++ b/src/main/java/org/mongojack/aggregation/UnwindAggregation.java
@@ -1,0 +1,33 @@
+package org.mongojack.aggregation;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Fluent builder for the mongo Unwind aggregation pipeline operation
+ * 
+ * @see <a href="http://docs.mongodb.org/manual/reference/operator/aggregation/unwind/">Mongo Aggregation - Unwind</a>
+ */
+public class UnwindAggregation extends AggregatePipelineOperation {
+
+    private DBObject unwind;
+
+    /**
+     * Create a new unwind operation
+     * 
+     * @param arrayFieldName the array field to unwind
+     */
+    public UnwindAggregation(String arrayFieldName) {
+        unwind = new BasicDBObject("$unwind", dollar(arrayFieldName));
+    }
+
+    @Override
+    public DBObject apply() {
+        return unwind;
+    }
+
+    @Override
+    public String toString() {
+        return unwind.toString();
+    }
+}

--- a/src/test/java/org/mongojack/TestAggregationBuilder.java
+++ b/src/test/java/org/mongojack/TestAggregationBuilder.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2014 Christopher Exell
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongojack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.core.Is;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mongojack.aggregation.AggregationBuilder;
+import org.mongojack.aggregation.GroupAggregation;
+import org.mongojack.aggregation.LimitAggregation;
+import org.mongojack.aggregation.MatchAggregation;
+import org.mongojack.aggregation.ProjectAggregation;
+import org.mongojack.aggregation.SortAggregation;
+import org.mongojack.aggregation.UnwindAggregation;
+import org.mongojack.mock.MockObject;
+import org.mongojack.mock.MockObjectAggregationResult;
+
+public class TestAggregationBuilder extends MongoDBTestBase {
+    private JacksonDBCollection<MockObject, String> coll;
+
+    @Before
+    public void setup() throws Exception {
+        coll = getCollection(MockObject.class, String.class);
+    }
+
+    @Test
+    public void testGroupSumSort() {
+        coll.insert(new MockObject("foo", 5));
+        coll.insert(new MockObject("foo", 6));
+        coll.insert(new MockObject("bar", 101));
+        coll.insert(new MockObject("bar", 102));
+
+        AggregationBuilder<MockObjectAggregationResult> builder = new AggregationBuilder<MockObjectAggregationResult>();
+        builder.group(new GroupAggregation("string").withSum("integer", "integer")).sort(new SortAggregation().descending("string"));
+
+        AggregationResult<MockObjectAggregationResult> aggregationResult = coll.aggregate(builder.build(MockObjectAggregationResult.class));
+
+        Assert.assertEquals(2, aggregationResult.results().size());
+
+        Assert.assertEquals("bar", aggregationResult.results().get(0)._id);
+        Assert.assertEquals(203, aggregationResult.results().get(0).integer.intValue());
+
+        Assert.assertEquals("foo", aggregationResult.results().get(1)._id);
+        Assert.assertEquals(11, aggregationResult.results().get(1).integer.intValue());
+    }
+
+    @Test
+    public void testMatchGroupMin() {
+
+        coll.insert(new MockObject("foo", 5));
+        coll.insert(new MockObject("foo", 6));
+        coll.insert(new MockObject("bar", 101));
+        coll.insert(new MockObject("bar", 102));
+
+        AggregationBuilder<MockObjectAggregationResult> builder = new AggregationBuilder<MockObjectAggregationResult>();
+        builder.match(new MatchAggregation("string", "foo"))
+                .group(new GroupAggregation("string").withMin("integer", "integer"));
+
+        AggregationResult<MockObjectAggregationResult> aggregationResult = coll.aggregate(builder.build(MockObjectAggregationResult.class));
+
+        Assert.assertEquals(1, aggregationResult.results().size());
+        Assert.assertEquals("foo", aggregationResult.results().get(0)._id);
+        Assert.assertEquals(5, aggregationResult.results().get(0).integer.intValue());
+    }
+
+    @Test
+    public void testGroupProject() {
+
+        coll.insert(new MockObject("foo", 5));
+        coll.insert(new MockObject("foo", 6));
+        coll.insert(new MockObject("bar", 101));
+        coll.insert(new MockObject("bar", 102));
+
+        AggregationBuilder<MockObjectAggregationResult> builder = new AggregationBuilder<MockObjectAggregationResult>();
+        builder.group(new GroupAggregation("string").withSum("integer", "integer"))
+                .project(new ProjectAggregation().set("integer", "string"));
+
+        AggregationResult<MockObjectAggregationResult> aggregationResult = coll.aggregate(builder.build(MockObjectAggregationResult.class));
+
+        Assert.assertEquals(2, aggregationResult.results().size());
+        Assert.assertEquals("203", aggregationResult.results().get(0).string);
+        Assert.assertEquals("11", aggregationResult.results().get(1).string);
+    }
+
+    @Test
+    public void testUnwindGroup() {
+
+        MockObject mock = new MockObject("foo", 5);
+        mock.simpleList = new ArrayList<String>();
+        mock.simpleList.add("bar");
+        mock.simpleList.add("baz");
+        mock.simpleList.add("qux");
+
+        coll.insert(mock);
+
+        AggregationBuilder<MockObjectAggregationResult> builder = new AggregationBuilder<MockObjectAggregationResult>();
+        builder.unwind(new UnwindAggregation("simpleList"))
+                .group(new GroupAggregation("string").withSum("integer", "integer"));
+
+        AggregationResult<MockObjectAggregationResult> aggregationResult = coll.aggregate(builder.build(MockObjectAggregationResult.class));
+
+        Assert.assertEquals(1, aggregationResult.results().size());
+        Assert.assertEquals(15, aggregationResult.results().get(0).integer.intValue());
+
+    }
+
+    @Test
+    public void testLimit() {
+
+        coll.insert(new MockObject("foo", 1));
+        coll.insert(new MockObject("bar", 1));
+        coll.insert(new MockObject("baz", 1));
+        coll.insert(new MockObject("qux", 1));
+
+        AggregationBuilder<MockObjectAggregationResult> builder = new AggregationBuilder<MockObjectAggregationResult>();
+        builder.group(new GroupAggregation("string"))
+                .limit(new LimitAggregation(2));
+
+        AggregationResult<MockObjectAggregationResult> aggregationResult = coll.aggregate(builder.build(MockObjectAggregationResult.class));
+
+        Assert.assertEquals(2, aggregationResult.results().size());
+
+    }
+    
+    @Test
+    public void testMatchUnaryComparison() {
+
+        coll.insert(new MockObject("foo", 1));
+        coll.insert(new MockObject("bar", 2));
+        coll.insert(new MockObject("baz", 3));
+        coll.insert(new MockObject("qux", 4));
+
+        AggregationBuilder<MockObjectAggregationResult> builder = new AggregationBuilder<MockObjectAggregationResult>();
+        builder.match(new MatchAggregation().greaterThan("integer", 2));
+
+        AggregationResult<MockObjectAggregationResult> aggregationResult = coll.aggregate(builder.build(MockObjectAggregationResult.class));
+
+        Assert.assertEquals(2, aggregationResult.results().size());
+        for (MockObjectAggregationResult mockObjectAggregationResult : aggregationResult.results()) {
+            Assert.assertTrue(mockObjectAggregationResult.integer > 2);
+        }
+
+    }
+    
+    @Test
+    public void testMatchIn() {
+
+        coll.insert(new MockObject("foo", 1));
+        coll.insert(new MockObject("bar", 2));
+        coll.insert(new MockObject("baz", 3));
+        coll.insert(new MockObject("qux", 4));
+
+        AggregationBuilder<MockObjectAggregationResult> builder = new AggregationBuilder<MockObjectAggregationResult>();
+        builder.match(new MatchAggregation().in("string", "foo", "baz"));
+
+        AggregationResult<MockObjectAggregationResult> aggregationResult = coll.aggregate(builder.build(MockObjectAggregationResult.class));
+
+        Assert.assertEquals(2, aggregationResult.results().size());
+        for (MockObjectAggregationResult mockObjectAggregationResult : aggregationResult.results()) {
+            Assert.assertTrue(mockObjectAggregationResult.string.equals("foo") ||  mockObjectAggregationResult.string.equals("baz"));
+        }
+
+    }
+}


### PR DESCRIPTION
This PR adds a fluent aggregation builder handy for creating Mongo aggregation pipelines with out having to create JSON by hand. You use the aggregation the way you would assemble a mongo query pipeline in JSON Best illustrated by example:

Take for instance a **customer** collection, with each customer having a nested array of users, eg:

```
{
   _id : "53051e678927e20c10f13295",
   name: "Foo Inc."
   users: [
     { 
       email: "bob@foo.com",
       status: "Active"
      },
      { 
       email: "dave@foo.com",
       status: "Deleted"
      },
    ]
}
```

Lets say you wanted to know many users there are by statys (ie 4 active, 3 Deleted etc):

```
AggregationBuilder<SimpleAggregationCount> builder= new AggregationBuilder<SimpleAggregationCount>();
        builder.unwind(new UnwindAggregation("users"))
        .group(new GroupAggregation("users.status").withCount("count"));        
        AggregationResult<SimpleAggregationCount> aggregationResult = collection.aggregate(builder.build(SimpleAggregationCount.class));
```

The equivalent query in mongo is

```
db.customer.aggregate({$unwind:"$users"}
, {$group:{
    _id:"$users.status"
    , count:{$sum:1}
    }
})
```
