### PR TITLE
Use embedded MongoDB for running the tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <version>1.46.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>1.3</version>
@@ -118,7 +123,22 @@
                     </dependency>
                 </dependencies>
             </plugin>
-
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.17</version>
+              <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>org.mongojack.testing.DbRunListener</value>
+                        </property>
+                    </properties>
+                    <systemPropertyVariables>
+                        <isMaven>true</isMaven>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -139,8 +159,8 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
+
         <extensions>
             <extension>
                 <groupId>com.github.stephenc.wagon</groupId>

--- a/src/test/java/org/mongojack/MongoDBTestBase.java
+++ b/src/test/java/org/mongojack/MongoDBTestBase.java
@@ -24,13 +24,12 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.mongojack.testing.DbManager;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
-import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
 
 /**
  * Base class for unit tests that run against MongoDB. Assumes there is a
@@ -56,7 +55,7 @@ public abstract class MongoDBTestBase {
         if (environment.containsKey(dbHostKey)) {
             mongo = new MongoClient(environment.get(dbHostKey));
         } else {
-            mongo = new MongoClient();
+            mongo = new MongoClient("localhost", DbManager.PORT);
         }
 
         db = mongo.getDB("unittest");

--- a/src/test/java/org/mongojack/MongoDBTestCaseRunner.java
+++ b/src/test/java/org/mongojack/MongoDBTestCaseRunner.java
@@ -28,6 +28,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
+import org.mongojack.testing.DbManager;
 
 /**
  * Runner that runs the tests through different permutations of configurations
@@ -147,6 +148,21 @@ public class MongoDBTestCaseRunner extends Suite {
         @Override
         protected Statement classBlock(RunNotifier notifier) {
             return childrenInvoker(notifier);
+        }
+    }
+
+    @Override
+    public void run(final RunNotifier notifier) {
+        // Maven instantiates the DbRunListener directly via the Surefire plugin
+        // If we're running in Eclipse then we start and stop the DB here since there
+        // doesn't appear to be an easy way to use a RunListener in Eclipse
+        String isMaven = System.getProperty("isMaven");
+        if (isMaven == null) {
+            DbManager.startDb();
+        }
+        super.run(notifier);
+        if (isMaven == null) {
+            DbManager.stopDb();
         }
     }
 

--- a/src/test/java/org/mongojack/testing/DbManager.java
+++ b/src/test/java/org/mongojack/testing/DbManager.java
@@ -1,0 +1,46 @@
+package org.mongojack.testing;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.runtime.Network;
+
+/**
+ * @author Ben McCann (benmccann.com)
+ */
+public class DbManager {
+
+  public static int PORT = 12345;
+
+  private static MongodProcess mongod = null;
+
+  public static void startDb() {
+    MongodStarter starter = MongodStarter.getDefaultInstance();
+
+    try {
+        IMongodConfig mongodConfig = new MongodConfigBuilder()
+            .version(Version.Main.V2_4)
+            .net(new Net(PORT, Network.localhostIsIPv6()))
+            .build();
+
+        MongodExecutable mongodExecutable = starter.prepare(mongodConfig);
+        mongod = mongodExecutable.start();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static void stopDb() {
+    if (mongod != null) {
+      mongod.stop();
+    }
+  }
+
+}

--- a/src/test/java/org/mongojack/testing/DbRunListener.java
+++ b/src/test/java/org/mongojack/testing/DbRunListener.java
@@ -1,0 +1,22 @@
+package org.mongojack.testing;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+
+/**
+ * @author Ben McCann (benmccann.com)
+ */
+public class DbRunListener extends RunListener {
+
+  @Override
+  public void testRunStarted(Description description) throws Exception {
+    DbManager.startDb();
+  }
+
+  @Override
+  public void testRunFinished(Result result) throws Exception {
+    DbManager.stopDb();
+  }
+
+}


### PR DESCRIPTION
This improves test predictability by ensuring the tests are always run with the same version of MongoDB instead of whatever random version happens to be installed on the current host

@roughy took your pull request https://github.com/devbliss/mongojack/pull/43 and updated it so that it would work in both Maven and Eclipse. Let me know if this looks okay to you as I would like to merge it soon
