### PR TITLE
Add failing test demonstrating StackOverflowError when serializing ObjectId

### DIFF
--- a/src/test/java/org/mongojack/TestCustomObjectMapper.java
+++ b/src/test/java/org/mongojack/TestCustomObjectMapper.java
@@ -72,6 +72,13 @@ public class TestCustomObjectMapper extends MongoDBTestBase {
         assertThat(saved.custom.value2, equalTo("world"));
     }
 
+    @Test
+    public void customObjectMapperShouldBeAbleToDeserializeObjectId() throws Exception {
+        ObjectMapper mapper = createObjectMapper();
+        final org.bson.types.ObjectId objectId = new org.bson.types.ObjectId();
+        assertThat(mapper.writeValueAsString(objectId), equalTo(objectId.toHexString()));
+    }
+
     public static class MockObject {
         @Id
         @ObjectId


### PR DESCRIPTION
This PR basically just adds a unit test for the error described on the mailing list in https://groups.google.com/d/msg/mongo-jackson-mapper/qsmrSOIQK0M/myBqOdFvgJ4J

When trying to serialize an `org.bson.types.ObjectId`, Jackson and the `ObjectIdSerializer` class get into an endless loop which ultimately leads to a `StackOverflowError`.

I've seen this error happen with any version after Jackson 2.6.2, so I guess something with the type resolution might have changed.