### PR TITLE
Fix for Issue #132

### DIFF
--- a/src/main/java/org/mongojack/JacksonDBCollection.java
+++ b/src/main/java/org/mongojack/JacksonDBCollection.java
@@ -765,8 +765,7 @@ public class JacksonDBCollection<T, K> {
      *             If an error occurred
      */
     public WriteResult<T, K> removeById(K id) throws MongoException {
-        return new WriteResult<T, K>(this,
-                dbCollection.remove(createIdQuery(id)));
+        return remove(createIdQuery(id));
     }
 
     /**


### PR DESCRIPTION
Query needs to be serialized before being passed along to DBCollection.remove().

See #132 for more detail.