### PR TITLE
Fix Java-type UUID serialization and deserialization

### DIFF
--- a/src/main/java/org/mongojack/internal/MongoJackDeserializers.java
+++ b/src/main/java/org/mongojack/internal/MongoJackDeserializers.java
@@ -18,6 +18,7 @@ package org.mongojack.internal;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.UUID;
 
 import org.mongojack.DBRef;
 
@@ -38,6 +39,7 @@ public class MongoJackDeserializers extends SimpleDeserializers {
     public MongoJackDeserializers() {
         addDeserializer(Date.class, new DateDeserializer());
         addDeserializer(Calendar.class, new CalendarDeserializer());
+        addDeserializer(UUID.class, new UUIDDeserializer());
     }
 
     @Override

--- a/src/main/java/org/mongojack/internal/MongoJackSerializers.java
+++ b/src/main/java/org/mongojack/internal/MongoJackSerializers.java
@@ -18,6 +18,7 @@ package org.mongojack.internal;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.UUID;
 
 import org.bson.types.ObjectId;
 
@@ -35,5 +36,6 @@ public class MongoJackSerializers extends SimpleSerializers {
         addSerializer(ObjectId.class, new ObjectIdSerializer());
         addSerializer(Date.class, new DateSerializer());
         addSerializer(Calendar.class, new CalendarSerializer());
+        addSerializer(UUID.class, new UUIDSerializer());
     }
 }

--- a/src/main/java/org/mongojack/internal/UUIDDeserializer.java
+++ b/src/main/java/org/mongojack/internal/UUIDDeserializer.java
@@ -1,0 +1,35 @@
+package org.mongojack.internal;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * A simple deserializer for Java UUIDs which prevents the regular Java
+ * data type from being converted to an inefficient string.
+ *
+ * @author Jared Tiala
+ * @since 2.6.2
+ */
+public class UUIDDeserializer extends JsonDeserializer<UUID> {
+
+    @Override
+    public UUID deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException {
+        JsonToken token = jp.getCurrentToken();
+
+        if (token == JsonToken.VALUE_EMBEDDED_OBJECT) {
+            Object object = jp.getEmbeddedObject();
+
+            if (object instanceof UUID) {
+                return (UUID) object;
+            }
+        }
+
+        throw ctxt.mappingException(UUID.class);
+    }
+}

--- a/src/main/java/org/mongojack/internal/UUIDSerializer.java
+++ b/src/main/java/org/mongojack/internal/UUIDSerializer.java
@@ -1,0 +1,24 @@
+package org.mongojack.internal;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * A simple serializer for Java UUIDs which prevents the regular Java
+ * data type from being converted to an inefficient string.
+ *
+ * @author Jared Tiala
+ * @since 2.6.2
+ */
+public class UUIDSerializer extends JsonSerializer<UUID> {
+
+    @Override
+    public void serialize(UUID uuid, JsonGenerator jgen,
+            SerializerProvider provider) throws IOException {
+        jgen.writeObject(uuid);
+    }
+}

--- a/src/main/java/org/mongojack/internal/object/BsonObjectCursor.java
+++ b/src/main/java/org/mongojack/internal/object/BsonObjectCursor.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.UUID;
 
 import org.bson.BSONObject;
 import org.bson.types.ObjectId;
@@ -212,6 +213,8 @@ abstract class BsonObjectCursor extends JsonStreamContext {
         } else if (o instanceof DBRef) {
             return JsonToken.VALUE_EMBEDDED_OBJECT;
         } else if (o instanceof Date) {
+            return JsonToken.VALUE_EMBEDDED_OBJECT;
+        } else if (o instanceof UUID) {
             return JsonToken.VALUE_EMBEDDED_OBJECT;
         } else if (o instanceof byte[]) {
             return JsonToken.VALUE_EMBEDDED_OBJECT;


### PR DESCRIPTION
By default, regular UUID fields are being serialized incorrectly causing them to be stored as strings instead of the predefined UUID object in the database. This is a waste of memory and causes problems when trying to retrieve POJOs by UUID. This issue has been around for a while (as seen in ticket #60) and is fixed by ensuring the object is written instead of the string value. Previous pull request closed in favour of this new one, which includes the deserializer classes.

![example](https://cloud.githubusercontent.com/assets/1208758/18038297/20146fe6-6d8e-11e6-9cbb-bd5feff34281.png)
