### PR TITLE
GH-141 - Handle targetIsCollection flag in CompoundQueryCondition

### DIFF
--- a/src/main/java/org/mongojack/DBQuery.java
+++ b/src/main/java/org/mongojack/DBQuery.java
@@ -617,7 +617,7 @@ public class DBQuery {
          * @return the query
          */
         public Q elemMatch(String field, Query query) {
-            return put(field, "$elemMatch", new CompoundQueryCondition(query));
+            return put(field, "$elemMatch", new CompoundQueryCondition(query, false));
         }
 
         /**
@@ -673,7 +673,9 @@ public class DBQuery {
             QueryCondition saved = query.get(field);
             if (!(saved instanceof CompoundQueryCondition)) {
                 subQuery = new Query();
-                query.put(field, new CompoundQueryCondition(subQuery));
+                boolean targetIsCollection = (value instanceof CollectionQueryCondition && ((CollectionQueryCondition)value).targetIsCollection())
+                    || (value instanceof CompoundQueryCondition && ((CompoundQueryCondition)value).targetIsCollection());
+                query.put(field, new CompoundQueryCondition(subQuery, targetIsCollection));
             } else {
                 subQuery = ((CompoundQueryCondition) saved).getQuery();
             }
@@ -696,7 +698,7 @@ public class DBQuery {
             }
             List<QueryCondition> conditions = new ArrayList<QueryCondition>();
             for (Query query : expressions) {
-                conditions.add(new CompoundQueryCondition(query));
+                conditions.add(new CompoundQueryCondition(query, false));
             }
             condition.addAll(conditions);
             return this;

--- a/src/main/java/org/mongojack/internal/query/CompoundQueryCondition.java
+++ b/src/main/java/org/mongojack/internal/query/CompoundQueryCondition.java
@@ -21,12 +21,18 @@ import org.mongojack.DBQuery;
 public class CompoundQueryCondition implements QueryCondition {
 
     private final DBQuery.Query query;
+    private final boolean targetIsCollection;
 
-    public CompoundQueryCondition(DBQuery.Query query) {
+    public CompoundQueryCondition(DBQuery.Query query, boolean targetIsCollection) {
         this.query = query;
+        this.targetIsCollection = targetIsCollection;
     }
 
     public DBQuery.Query getQuery() {
         return query;
+    }
+    
+    public boolean targetIsCollection() {
+        return targetIsCollection;
     }
 }

--- a/src/main/java/org/mongojack/internal/util/DocumentSerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/DocumentSerializationUtils.java
@@ -99,7 +99,7 @@ public class DocumentSerializationUtils {
     /**
      * Serialize the fields of the given object using the given object mapper.
      * This will convert POJOs to Documents where necessary.
-     * 
+     *
      * @param objectMapper
      *            The object mapper to use to do the serialization
      * @param object
@@ -173,7 +173,7 @@ public class DocumentSerializationUtils {
             if (!simple.requiresSerialization() || simple.getValue() == null) {
                 return simple.getValue();
             } else {
-                if (!key.startsWith("$")) {
+                if (!isOperator(key)) {
                     serializer = findQuerySerializer(false, key,
                             serializerProvider, serializer);
                 }
@@ -182,7 +182,7 @@ public class DocumentSerializationUtils {
             }
         } else if (condition instanceof CollectionQueryCondition) {
             CollectionQueryCondition coll = (CollectionQueryCondition) condition;
-            if (!key.startsWith("$")) {
+            if (!isOperator(key)) {
                 serializer = findQuerySerializer(coll.targetIsCollection(),
                         key, serializerProvider, serializer);
             }
@@ -194,12 +194,16 @@ public class DocumentSerializationUtils {
             return serializedConditions;
         } else {
             CompoundQueryCondition compound = (CompoundQueryCondition) condition;
-            if (!key.startsWith("$")) {
-                serializer = findQuerySerializer(false, key, serializerProvider, serializer);
+            if (!isOperator(key)) {
+                serializer = findQuerySerializer(compound.targetIsCollection(), key, serializerProvider, serializer);
             }
             return serializeQuery(serializerProvider, serializer,
                     compound.getQuery());
         }
+    }
+
+    private static boolean isOperator(String key) {
+        return key.startsWith("$");
     }
 
     private static Object serializeQueryField(Object value,
@@ -269,7 +273,7 @@ public class DocumentSerializationUtils {
 
     /**
      * Serialize the given field
-     * 
+     *
      * @param objectMapper
      *            The object mapper to serialize it with
      * @param value

--- a/src/main/java/org/mongojack/internal/util/SerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/SerializationUtils.java
@@ -34,7 +34,6 @@ import org.mongojack.Aggregation;
 import org.mongojack.Aggregation.Expression;
 import org.mongojack.Aggregation.Group.Accumulator;
 import org.mongojack.Aggregation.Pipeline;
-import org.mongojack.Aggregation.Pipeline.Stage;
 import org.mongojack.DBProjection.ProjectionBuilder;
 import org.mongojack.DBQuery;
 import org.mongojack.DBRef;
@@ -174,7 +173,7 @@ public class SerializationUtils {
             if (!simple.requiresSerialization() || simple.getValue() == null) {
                 return simple.getValue();
             } else {
-                if (!key.startsWith("$")) {
+                if (!isOperator(key)) {
                     serializer = findQuerySerializer(false, key,
                             serializerProvider, serializer);
                 }
@@ -183,7 +182,7 @@ public class SerializationUtils {
             }
         } else if (condition instanceof CollectionQueryCondition) {
             CollectionQueryCondition coll = (CollectionQueryCondition) condition;
-            if (!key.startsWith("$")) {
+            if (!isOperator(key)) {
                 serializer = findQuerySerializer(coll.targetIsCollection(),
                         key, serializerProvider, serializer);
             }
@@ -196,12 +195,16 @@ public class SerializationUtils {
         } else {
             CompoundQueryCondition compound = (CompoundQueryCondition) condition;
             if (!key.startsWith("$")) {
-                serializer = findQuerySerializer(false, key, serializerProvider, serializer);
+                serializer = findQuerySerializer(compound.targetIsCollection(), key, serializerProvider, serializer);
             }
             return serializeQuery(serializerProvider, serializer,
                     compound.getQuery());
         }
     }
+
+	private static boolean isOperator(String key) {
+		return key.startsWith("$");
+	}
 
     private static Object serializeQueryField(Object value,
             JsonSerializer serializer, SerializerProvider serializerProvider,

--- a/src/main/java/org/mongojack/internal/util/SerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/SerializationUtils.java
@@ -194,7 +194,7 @@ public class SerializationUtils {
             return serializedConditions;
         } else {
             CompoundQueryCondition compound = (CompoundQueryCondition) condition;
-            if (!key.startsWith("$")) {
+            if (!isOperator(key)) {
                 serializer = findQuerySerializer(compound.targetIsCollection(), key, serializerProvider, serializer);
             }
             return serializeQuery(serializerProvider, serializer,

--- a/src/test/java/org/mongojack/TestQuerySerialization.java
+++ b/src/test/java/org/mongojack/TestQuerySerialization.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mongojack.DBQuery.Query;
 
@@ -77,7 +76,7 @@ public class TestQuerySerialization extends MongoDBTestBase {
                         .toArray(), hasSize(1));
     }
 
-    @Test @Ignore // This test needs to be fixed
+    @Test
     public void testIn_collectionOfStrings() {
         DBCollection c1 = getCollection("blah_" + Math.round(Math.random() * 10000d));
         JacksonDBCollection<MockObjectWithList, String> c2 = JacksonDBCollection.wrap(c1, MockObjectWithList.class, String.class);

--- a/src/test/java/org/mongojack/TestQuerySerialization.java
+++ b/src/test/java/org/mongojack/TestQuerySerialization.java
@@ -56,6 +56,9 @@ public class TestQuerySerialization extends MongoDBTestBase {
     public void testSimpleEquals() {
         coll.save(new MockObject());
         String id = coll.findOne().id;
+        // with DBCursor
+        assertNotNull(coll.find().is("_id", id).next());
+        // with DBQuery
         assertNotNull(coll.findOne(DBQuery.is("_id", id)));
     }
 
@@ -63,9 +66,14 @@ public class TestQuerySerialization extends MongoDBTestBase {
     public void testIn() {
         coll.save(new MockObject());
         String id = coll.findOne().id;
+        // with DBCursor
         assertThat(
                 coll.find()
                         .in("_id", id, new org.bson.types.ObjectId().toString())
+                        .toArray(), hasSize(1));
+        // with DBQuery
+        assertThat(
+                coll.find(DBQuery.in("_id", id, new org.bson.types.ObjectId().toString()))
                         .toArray(), hasSize(1));
     }
 
@@ -79,7 +87,7 @@ public class TestQuerySerialization extends MongoDBTestBase {
         Query q = DBQuery.in("simpleList", x);
         c2.find(q);
     }
-    
+
     @Test
     public void testLessThan() {
         MockObject o = new MockObject();
@@ -88,7 +96,10 @@ public class TestQuerySerialization extends MongoDBTestBase {
         // Ensure that the serializer actually worked
         assertThat((Integer) coll.getDbCollection().findOne().get("i"),
                 equalTo(15));
+        // with DBCursor
         assertThat(coll.find().lessThan("i", 12).toArray(), hasSize(1));
+        // with DBQuery
+        assertThat(coll.find(DBQuery.lessThan("i", 12)).toArray(), hasSize(1));
     }
 
     @Test
@@ -97,6 +108,7 @@ public class TestQuerySerialization extends MongoDBTestBase {
         o.i = 5;
         coll.save(o);
         // Ensure that the serializer actually worked
+        // with DBCursor
         assertThat(
                 coll.find()
                         .and(DBQuery.lessThan("i", 12),
@@ -106,6 +118,13 @@ public class TestQuerySerialization extends MongoDBTestBase {
                 coll.find()
                         .and(DBQuery.lessThan("i", 12),
                                 DBQuery.greaterThan("i", 9)).toArray(),
+                hasSize(0));
+        // with DBQuery
+        assertThat(
+            coll.find(DBQuery.and(DBQuery.lessThan("i", 12), DBQuery.greaterThan("i", 4))).toArray(),
+                hasSize(1));
+        assertThat(
+            coll.find(DBQuery.and(DBQuery.lessThan("i", 12), DBQuery.greaterThan("i", 9))).toArray(),
                 hasSize(0));
     }
 
@@ -118,7 +137,10 @@ public class TestQuerySerialization extends MongoDBTestBase {
         coll.save(o);
 
         // Ensure that the serializer actually worked
+        // with DBCursor
         assertThat(coll.find().all("items", o1).toArray(), hasSize(1));
+        // with DBQuery
+        assertThat(coll.find(DBQuery.all("items", o1)).toArray(), hasSize(1));
     }
 
     @Test
@@ -129,7 +151,10 @@ public class TestQuerySerialization extends MongoDBTestBase {
         o.items = Arrays.asList(o1);
         coll.save(o);
 
+        // with DBCursor
         assertThat(coll.find().is("items._id", o1.id).toArray(), hasSize(1));
+        // with DBQuery
+        assertThat(coll.find(DBQuery.is("items._id", o1.id)).toArray(), hasSize(1));
     }
 
     @Test
@@ -140,7 +165,11 @@ public class TestQuerySerialization extends MongoDBTestBase {
         o.items = Arrays.asList(o1);
         coll.save(o);
 
+        // with DBCursor
         assertThat(coll.find().is("items", Arrays.asList(o1)).toArray(),
+                hasSize(1));
+        // with DBQuery
+        assertThat(coll.find(DBQuery.is("items", Arrays.asList(o1))).toArray(),
                 hasSize(1));
     }
 


### PR DESCRIPTION
Keep the targetIsCollection in the CompoundQueryCondition so that the element serializer is used to serialize the query and not the collection serializer.

See GH-141
