### PR TITLE
MongoDB 3.6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver</artifactId>
-      <version>3.5.0</version>
+      <version>3.6.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/mongojack/DBUpdate.java
+++ b/src/main/java/org/mongojack/DBUpdate.java
@@ -395,7 +395,7 @@ public class DBUpdate {
          * @return this object
          */
         public Builder pushAll(String field, Object... values) {
-            return addOperation("$pushAll", field,
+            return addOperation("$push", field,
                     new MultiUpdateOperationValue(true, true, values));
         }
 
@@ -410,7 +410,7 @@ public class DBUpdate {
          * @return this object
          */
         public Builder pushAll(String field, List<?> values) {
-            return addOperation("$pushAll", field,
+            return addOperation("$push", field,
                     new MultiUpdateOperationValue(true, true, values));
         }
 

--- a/src/main/java/org/mongojack/internal/util/SerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/SerializationUtils.java
@@ -375,9 +375,10 @@ public class SerializationUtils {
                 } else {
                     value = field.getValue().getValue();
                 }
-                if (op.getKey().equals("$addToSet")
+                if ((op.getKey().equals("$addToSet") || op.getKey().equals("$push"))
                         && field.getValue() instanceof MultiUpdateOperationValue) {
                     // Add to set needs $each for multi values
+                    // Same for $push with MultiUpdateOperation
                     opObject.put(field.getKey(), new BasicDBObject("$each",
                             value));
                 } else {

--- a/src/test/java/org/mongojack/TestJacksonMongoCollection.java
+++ b/src/test/java/org/mongojack/TestJacksonMongoCollection.java
@@ -18,11 +18,13 @@ package org.mongojack;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.bson.Document;
@@ -84,6 +86,12 @@ public class TestJacksonMongoCollection extends MongoDBTestBase {
         coll.insert(new MockObject("id1", "ten", 10));
         coll.insert(new MockObject("id2", "ten", 10));
 
+        MockObject mockObject3 = new MockObject("id3", "ten", 10);
+        mockObject3.simpleList = new ArrayList<>();
+        mockObject3.simpleList.add("a");
+        mockObject3.simpleList.add("b");
+        coll.insert(mockObject3);
+
         MockObject result1 = coll.findAndModify(DBQuery.is("_id", "id1"), null,
                 null, DBUpdate.set("integer", 20)
                         .set("string", "twenty"), true, false);
@@ -96,9 +104,15 @@ public class TestJacksonMongoCollection extends MongoDBTestBase {
         assertThat(result2.integer, equalTo(30));
         assertThat(result2.string, equalTo("thirty"));
 
+        MockObject result3 = coll.findAndModify(DBQuery.is("_id", "id3"), null,
+                null, DBUpdate.pushAll("simpleList", Arrays.asList("1", "2", "3")),
+                true, false);
+        assertThat(result3.simpleList, hasSize(5));
+        assertThat(result3.simpleList, hasItems("1", "2", "3"));
+
         coll.removeById("id1");
         coll.removeById("id2");
-
+        coll.removeById("id3");
     }
 
 }

--- a/src/test/java/org/mongojack/testing/DbManager.java
+++ b/src/test/java/org/mongojack/testing/DbManager.java
@@ -24,7 +24,7 @@ public class DbManager {
 
     try {
         IMongodConfig mongodConfig = new MongodConfigBuilder()
-            .version(Version.Main.V3_2)
+            .version(Version.Main.V3_6)
             .net(new Net(PORT, Network.localhostIsIPv6()))
             .build();
 


### PR DESCRIPTION
Add compatibility with MongoDB 3.6:
- changed `$pushAll` to `$push`+`$each` as `$pushAll` was removed.