### PR TITLE
Patch for Issue #184, Add support for java.time.*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,6 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.8.7</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>2.8.7</version>
     </dependency>
@@ -392,6 +387,13 @@
     <contributor>
       <name>Christopher O'Grady</name>
       <url>https://github.com/cfogrady</url>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </contributor>
+    <contributor>
+      <name>David Nebinger</name>
+      <url>https://github.com/dnebing</url>
       <roles>
         <role>developer</role>
       </roles>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,16 @@
       <version>2.8.7</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>2.8.7</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.8.7</version>
+    </dependency>
+    <dependency>
       <groupId>de.undercouch</groupId>
       <artifactId>bson4jackson</artifactId>
       <version>2.7.0</version>

--- a/src/main/java/org/mongojack/JacksonDBCollection.java
+++ b/src/main/java/org/mongojack/JacksonDBCollection.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.mongojack.internal.FetchableDBRef;
 import org.mongojack.internal.JacksonCollectionKey;
 import org.mongojack.internal.MongoJackModule;
@@ -272,6 +273,9 @@ public class JacksonDBCollection<T, K> {
      */
     public JacksonDBCollection<T, K> enable(Feature feature) {
         features.put(feature, true);
+        if (feature == Feature.WRITE_DATES_AS_TIMESTAMPS) {
+            objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
+        }
         return this;
     }
 
@@ -284,6 +288,9 @@ public class JacksonDBCollection<T, K> {
      */
     public JacksonDBCollection<T, K> disable(Feature feature) {
         features.put(feature, false);
+        if (feature == Feature.WRITE_DATES_AS_TIMESTAMPS) {
+            objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        }
         return this;
     }
 

--- a/src/main/java/org/mongojack/JacksonDBCollection.java
+++ b/src/main/java/org/mongojack/JacksonDBCollection.java
@@ -90,7 +90,15 @@ public class JacksonDBCollection<T, K> {
          * to the server, which means WriteResult.getSavedId() getSavedObject()
          * will not work. Hence it is disabled by default.
          */
-        USE_STREAM_SERIALIZATION(false);
+        USE_STREAM_SERIALIZATION(false),
+
+        /**
+         * For Java 8 time objects introduced by JSR 310, this feature will enable
+         * or disable the writing of dates as timestamps for MongoDB. When disabled,
+         * a LocalDateTime will be an array of ints, [YYYY, M, D, H, m, s, S] but,
+         * when enabled, will be a string "YYYY-MM-DDTHH:mm:ss.S" per the ISO format.
+         */
+        WRITE_DATES_AS_TIMESTAMPS(true);
 
         Feature(boolean enabledByDefault) {
             this.enabledByDefault = enabledByDefault;

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -16,6 +16,7 @@
  */
 package org.mongojack.internal;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.mongojack.internal.stream.ServerErrorProblemHandler;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -31,7 +32,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class MongoJackModule extends Module {
     public static final Module INSTANCE = new MongoJackModule();
-
+    public static final Module JAVATIME = new JavaTimeModule();
+    
     /**
      * Configure the given object mapper to be used with MongoJack. Please call
      * this method rather than calling

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -54,7 +54,7 @@ public class MongoJackModule extends Module {
 
         // disable serialize dates as timestamps because we have fewer runtime errors that way
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        
+
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;
     }

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -16,6 +16,7 @@
  */
 package org.mongojack.internal;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.mongojack.internal.stream.ServerErrorProblemHandler;
 
@@ -51,6 +52,9 @@ public class MongoJackModule extends Module {
         // register java time module
         objectMapper.registerModule(JAVATIME);
 
+        // disable serialize dates as timestamps because we have fewer runtime errors that way
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;
     }

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class MongoJackModule extends Module {
     public static final Module INSTANCE = new MongoJackModule();
     public static final Module JAVATIME = new JavaTimeModule();
-    
+
     /**
      * Configure the given object mapper to be used with MongoJack. Please call
      * this method rather than calling
@@ -47,6 +47,10 @@ public class MongoJackModule extends Module {
      */
     public static ObjectMapper configure(ObjectMapper objectMapper) {
         objectMapper.registerModule(INSTANCE);
+
+        // register java time module
+        objectMapper.registerModule(JAVATIME);
+
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;
     }

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -3,6 +3,7 @@ package org.mongojack;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -516,7 +517,7 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
     /*
         Like ZonedDateTime, OffsetDateTime serializes to a BigDecimal when writing dates as timestamps.
         Since MongoJack does not support BigDecimals, this type cannot be serialized.
-        
+
     @Test
     public void testOffsetDateTimeSavedAsTimestamps() {
         // create the object
@@ -572,5 +573,67 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
         // verify it
         assertThat(result._id, equalTo(id));
         assertThat(result.offsetDateTime, equalTo(object.offsetDateTime));
+    }
+
+    public static class DurationContainer {
+        public org.bson.types.ObjectId _id;
+        public Duration duration;
+    }
+
+    /*
+        Like ZonedDateTime, Duration serializes to a BigDecimal when writing as a timestamp, since MongoJack does
+        not serialize BigDecimals, Duration serialization as a timestamp is not supported.
+        
+    @Test
+    public void testDurationSavedAsTimestamps() {
+        // create the object
+        DurationContainer object = new DurationContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.duration = Duration.ofMinutes(2047);
+
+        // get a container
+        JacksonDBCollection<DurationContainer, org.bson.types.ObjectId> coll = getCollection(DurationContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        DurationContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.duration, equalTo(object.duration));
+    }
+    */
+
+    @Test
+    public void testDurationSavedAsISO8601() {
+        // create the object
+        DurationContainer object = new DurationContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.duration = Duration.ofMinutes(2047);
+
+        // get a container
+        JacksonDBCollection<DurationContainer, org.bson.types.ObjectId> coll = getCollection(DurationContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        DurationContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.duration, equalTo(object.duration));
     }
 }

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -33,6 +33,35 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
         JacksonDBCollection<LocalDateContainer, org.bson.types.ObjectId> coll = getCollection(LocalDateContainer.class,
                 org.bson.types.ObjectId.class);
 
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        LocalDateContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.localDate, equalTo(object.localDate));
+    }
+
+    @Test
+    public void testLocalDateSavedAsISO8601() {
+        // create the object
+        LocalDateContainer object = new LocalDateContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.localDate = LocalDate.now();
+
+        // get a container
+        JacksonDBCollection<LocalDateContainer, org.bson.types.ObjectId> coll = getCollection(LocalDateContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
         // save the object
         coll.insert(object);
 

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -1,0 +1,9 @@
+package org.mongojack;
+
+/**
+ * class TestJavaTimeHandling: Tests the java.time.* handling in MongoJack.
+ *
+ * @author dnebinger 
+ */
+public class TestJavaTimeHandling extends MongoDBTestBase {
+}

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -7,6 +7,9 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.Year;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -207,7 +210,7 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
 
         So this test is disabled because it will fail.
 
-        
+
     @Test
     public void testZonedDateTimeSavedAsTimestamps() {
         // create the object
@@ -266,5 +269,176 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
         // verify it
         assertThat(result._id, equalTo(id));
         assertTrue(result.zonedDateTime.isEqual(object.zonedDateTime));
+    }
+
+    public static class YearContainer {
+        public org.bson.types.ObjectId _id;
+        public Year year;
+    }
+
+    @Test
+    public void testYearSavedAsTimestamps() {
+        // create the object
+        YearContainer object = new YearContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.year = Year.now();
+
+        // get a container
+        JacksonDBCollection<YearContainer, org.bson.types.ObjectId> coll = getCollection(YearContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        YearContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.year, equalTo(object.year));
+    }
+
+    @Test
+    public void testYearSavedAsISO8601() {
+        // create the object
+        YearContainer object = new YearContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.year = Year.now();
+
+        // get a container
+        JacksonDBCollection<YearContainer, org.bson.types.ObjectId> coll = getCollection(YearContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        YearContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.year, equalTo(object.year));
+    }
+
+    public static class YearMonthContainer {
+        public org.bson.types.ObjectId _id;
+        public YearMonth yearMonth;
+    }
+
+    @Test
+    public void testYearMonthSavedAsTimestamps() {
+        // create the object
+        YearMonthContainer object = new YearMonthContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.yearMonth = YearMonth.now();
+
+        // get a container
+        JacksonDBCollection<YearMonthContainer, org.bson.types.ObjectId> coll = getCollection(YearMonthContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        YearMonthContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.yearMonth, equalTo(object.yearMonth));
+    }
+
+    @Test
+    public void testYearMonthSavedAsISO8601() {
+        // create the object
+        YearMonthContainer object = new YearMonthContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.yearMonth = YearMonth.now();
+
+        // get a container
+        JacksonDBCollection<YearMonthContainer, org.bson.types.ObjectId> coll = getCollection(YearMonthContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        YearMonthContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.yearMonth, equalTo(object.yearMonth));
+    }
+
+    public static class MonthDayContainer {
+        public org.bson.types.ObjectId _id;
+        public MonthDay monthDay;
+    }
+
+    @Test
+    public void testMonthDaySavedAsTimestamps() {
+        // create the object
+        MonthDayContainer object = new MonthDayContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.monthDay = MonthDay.now();
+
+        // get a container
+        JacksonDBCollection<MonthDayContainer, org.bson.types.ObjectId> coll = getCollection(MonthDayContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        MonthDayContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.monthDay, equalTo(object.monthDay));
+    }
+
+    @Test
+    public void testMonthDaySavedAsISO8601() {
+        // create the object
+        MonthDayContainer object = new MonthDayContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.monthDay = MonthDay.now();
+
+        // get a container
+        JacksonDBCollection<MonthDayContainer, org.bson.types.ObjectId> coll = getCollection(MonthDayContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        MonthDayContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.monthDay, equalTo(object.monthDay));
     }
 }

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -8,9 +8,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.time.Year;
 import java.time.YearMonth;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -440,5 +443,134 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
         // verify it
         assertThat(result._id, equalTo(id));
         assertThat(result.monthDay, equalTo(object.monthDay));
+    }
+
+    public static class OffsetTimeContainer {
+        public org.bson.types.ObjectId _id;
+        public OffsetTime offsetTime;
+    }
+
+    @Test
+    public void testOffsetTimeSavedAsTimestamps() {
+        // create the object
+        OffsetTimeContainer object = new OffsetTimeContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        LocalTime now = LocalTime.now();
+        OffsetTime offsetTime = OffsetTime.of(now, ZoneOffset.UTC);
+
+        object.offsetTime = offsetTime;
+
+        // get a container
+        JacksonDBCollection<OffsetTimeContainer, org.bson.types.ObjectId> coll = getCollection(OffsetTimeContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        OffsetTimeContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.offsetTime, equalTo(object.offsetTime));
+    }
+
+    @Test
+    public void testOffsetTimeSavedAsISO8601() {
+        // create the object
+        OffsetTimeContainer object = new OffsetTimeContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        LocalTime now = LocalTime.now();
+        OffsetTime offsetTime = OffsetTime.of(now, ZoneOffset.UTC);
+
+        object.offsetTime = offsetTime;
+
+        // get a container
+        JacksonDBCollection<OffsetTimeContainer, org.bson.types.ObjectId> coll = getCollection(OffsetTimeContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        OffsetTimeContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.offsetTime, equalTo(object.offsetTime));
+    }
+
+    public static class OffsetDateTimeContainer {
+        public org.bson.types.ObjectId _id;
+        public OffsetDateTime offsetDateTime;
+    }
+
+    /*
+        Like ZonedDateTime, OffsetDateTime serializes to a BigDecimal when writing dates as timestamps.
+        Since MongoJack does not support BigDecimals, this type cannot be serialized.
+        
+    @Test
+    public void testOffsetDateTimeSavedAsTimestamps() {
+        // create the object
+        OffsetDateTimeContainer object = new OffsetDateTimeContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        OffsetDateTime offsetTime = OffsetDateTime.of(LocalDate.now(), LocalTime.now(), ZoneOffset.UTC);
+
+        object.offsetDateTime = offsetTime;
+
+        // get a container
+        JacksonDBCollection<OffsetDateTimeContainer, org.bson.types.ObjectId> coll = getCollection(OffsetDateTimeContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        OffsetDateTimeContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.offsetDateTime, equalTo(object.offsetDateTime));
+    }
+     */
+
+    @Test
+    public void testOffsetDateTimeSavedAsISO8601() {
+        // create the object
+        OffsetDateTimeContainer object = new OffsetDateTimeContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        OffsetDateTime offsetTime = OffsetDateTime.of(LocalDate.now(), LocalTime.now(), ZoneOffset.UTC);
+
+        object.offsetDateTime = offsetTime;
+
+        // get a container
+        JacksonDBCollection<OffsetDateTimeContainer, org.bson.types.ObjectId> coll = getCollection(OffsetDateTimeContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        OffsetDateTimeContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.offsetDateTime, equalTo(object.offsetDateTime));
     }
 }

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -131,5 +132,64 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
         // verify it
         assertThat(result._id, equalTo(id));
         assertThat(result.localTime, equalTo(object.localTime));
+    }
+
+    public static class LocalDateTimeContainer {
+        public org.bson.types.ObjectId _id;
+        public LocalDateTime localDateTime;
+    }
+
+    @Test
+    public void testLocalDateTimeSavedAsTimestamps() {
+        // create the object
+        LocalDateTimeContainer object = new LocalDateTimeContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        LocalDateTime time = LocalDateTime.now();
+        object.localDateTime = time;
+
+        // get a container
+        JacksonDBCollection<LocalDateTimeContainer, org.bson.types.ObjectId> coll = getCollection(LocalDateTimeContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        LocalDateTimeContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.localDateTime, equalTo(object.localDateTime));
+    }
+
+    @Test
+    public void testLocalDateTimeSavedAsISO8601() {
+        // create the object
+        LocalDateTimeContainer object = new LocalDateTimeContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        LocalDateTime time = LocalDateTime.now();
+        object.localDateTime = time;
+
+        // get a container
+        JacksonDBCollection<LocalDateTimeContainer, org.bson.types.ObjectId> coll = getCollection(LocalDateTimeContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        LocalDateTimeContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.localDateTime, equalTo(object.localDateTime));
     }
 }

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -645,7 +645,7 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
     /*
         Like ZonedDateTime, an Instant serializes to a BigDecimal when writing dates as timestamps.  Since BigDecimals
         are not supported by MongoJack, neither can we support serialization of Instants.
-        
+
     @Test
     public void testInstantSavedAsTimestamps() {
         // create the object

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -1,9 +1,46 @@
 package org.mongojack;
 
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
 /**
  * class TestJavaTimeHandling: Tests the java.time.* handling in MongoJack.
  *
- * @author dnebinger 
+ * @author dnebinger
  */
 public class TestJavaTimeHandling extends MongoDBTestBase {
+
+    public static class LocalDateContainer {
+        public org.bson.types.ObjectId _id;
+        public LocalDate localDate;
+    }
+
+    @Test
+    public void testLocalDateSavedAsTimestamps() {
+        // create the object
+        LocalDateContainer object = new LocalDateContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.localDate = LocalDate.now();
+
+        // get a container
+        JacksonDBCollection<LocalDateContainer, org.bson.types.ObjectId> coll = getCollection(LocalDateContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        LocalDateContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.localDate, equalTo(object.localDate));
+    }
 }

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -583,7 +583,7 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
     /*
         Like ZonedDateTime, Duration serializes to a BigDecimal when writing as a timestamp, since MongoJack does
         not serialize BigDecimals, Duration serialization as a timestamp is not supported.
-        
+
     @Test
     public void testDurationSavedAsTimestamps() {
         // create the object
@@ -635,5 +635,67 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
         // verify it
         assertThat(result._id, equalTo(id));
         assertThat(result.duration, equalTo(object.duration));
+    }
+
+    public static class InstantContainer {
+        public org.bson.types.ObjectId _id;
+        public Instant instant;
+    }
+
+    /*
+        Like ZonedDateTime, an Instant serializes to a BigDecimal when writing dates as timestamps.  Since BigDecimals
+        are not supported by MongoJack, neither can we support serialization of Instants.
+        
+    @Test
+    public void testInstantSavedAsTimestamps() {
+        // create the object
+        InstantContainer object = new InstantContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.instant = Instant.now().plus(Duration.ofHours(3).plusMinutes(8));
+
+        // get a container
+        JacksonDBCollection<InstantContainer, org.bson.types.ObjectId> coll = getCollection(InstantContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        InstantContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.instant, equalTo(object.instant));
+    }
+    */
+
+    @Test
+    public void testInstantSavedAsISO8601() {
+        // create the object
+        InstantContainer object = new InstantContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        object.instant = Instant.now().plus(Duration.ofHours(3).plusMinutes(8));
+
+        // get a container
+        JacksonDBCollection<InstantContainer, org.bson.types.ObjectId> coll = getCollection(InstantContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        InstantContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.instant, equalTo(object.instant));
     }
 }

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -71,5 +72,64 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
         // verify it
         assertThat(result._id, equalTo(id));
         assertThat(result.localDate, equalTo(object.localDate));
+    }
+
+    public static class LocalTimeContainer {
+        public org.bson.types.ObjectId _id;
+        public LocalTime localTime;
+    }
+
+    @Test
+    public void testLocalTimeSavedAsTimestamps() {
+        // create the object
+        LocalTimeContainer object = new LocalTimeContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        LocalTime time = LocalTime.now();
+        object.localTime = time;
+
+        // get a container
+        JacksonDBCollection<LocalTimeContainer, org.bson.types.ObjectId> coll = getCollection(LocalTimeContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.enable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        LocalTimeContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.localTime, equalTo(object.localTime));
+    }
+
+    @Test
+    public void testLocalTimeSavedAsISO8601() {
+        // create the object
+        LocalTimeContainer object = new LocalTimeContainer();
+        org.bson.types.ObjectId id = new org.bson.types.ObjectId();
+        object._id = id;
+        LocalTime time = LocalTime.now();
+        object.localTime = time;
+
+        // get a container
+        JacksonDBCollection<LocalTimeContainer, org.bson.types.ObjectId> coll = getCollection(LocalTimeContainer.class,
+                org.bson.types.ObjectId.class);
+
+        // enable as timestamps.
+        coll.disable(JacksonDBCollection.Feature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // save the object
+        coll.insert(object);
+
+        // retrieve it
+        LocalTimeContainer result = coll.findOneById(id);
+
+        // verify it
+        assertThat(result._id, equalTo(id));
+        assertThat(result.localTime, equalTo(object.localTime));
     }
 }


### PR DESCRIPTION
Adds support into MongoJack to handle java.time.* conversions like JDBC 4.2 level drivers do.

Significant changes include an addition to MongoJackModule to register the JavaTimeModule, update Feature of JacksonDBCollection for the WRITE_DATES_AS_TIMESTAMPS handling and a JUnit test class to test all of the convers