### PR TITLE
Add patched java.time.Instant deserializer for bson4jackson parse output

### DIFF
--- a/src/main/java/org/mongojack/internal/MongoJackDeserializers.java
+++ b/src/main/java/org/mongojack/internal/MongoJackDeserializers.java
@@ -16,6 +16,7 @@
  */
 package org.mongojack.internal;
 
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
@@ -38,6 +39,7 @@ import com.fasterxml.jackson.databind.module.SimpleDeserializers;
 public class MongoJackDeserializers extends SimpleDeserializers {
     public MongoJackDeserializers() {
         addDeserializer(Date.class, new DateDeserializer());
+        addDeserializer(Instant.class, new MongoJackInstantDeserializer());
         addDeserializer(Calendar.class, new CalendarDeserializer());
         addDeserializer(UUID.class, new UUIDDeserializer());
     }

--- a/src/main/java/org/mongojack/internal/MongoJackInstantDeserializer.java
+++ b/src/main/java/org/mongojack/internal/MongoJackInstantDeserializer.java
@@ -1,0 +1,41 @@
+package org.mongojack.internal;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+
+/**
+ * Patched {@link java.time.Instant} deserializer. Works with bson4jackson-deserialized ISODate() fields
+ *
+ * @author Mikhail Surin
+ */
+public class MongoJackInstantDeserializer extends InstantDeserializer<Instant> {
+    public MongoJackInstantDeserializer() {
+        super(Instant.class, DateTimeFormatter.ISO_INSTANT,
+                Instant::from,
+                a -> Instant.ofEpochMilli(a.value),
+                a -> Instant.ofEpochSecond(a.integer, a.fraction),
+                null,
+                true);
+    }
+
+    @Override
+    public Instant deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        if (parser.getCurrentTokenId() == JsonTokenId.ID_EMBEDDED_OBJECT) {
+            Object embeddedObject = parser.getEmbeddedObject();
+            if (embeddedObject instanceof Instant) {
+                return (Instant) embeddedObject;
+            }
+            if (embeddedObject instanceof Date) {
+                return ((Date) embeddedObject).toInstant();
+            }
+        }
+        return super.deserialize(parser, context);
+    }
+}

--- a/src/test/java/org/mongojack/internal/util/MongoJackInstantDeserializerTest.java
+++ b/src/test/java/org/mongojack/internal/util/MongoJackInstantDeserializerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014 devbliss GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongojack.internal.util;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mongojack.internal.MongoJackInstantDeserializer;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link MongoJackInstantDeserializer}
+ *
+ * @author antimony
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MongoJackInstantDeserializerTest {
+
+    private static final long TIME_AS_LONG = 1065l;
+
+    @Mock
+    private Date date;
+
+    @Mock
+    private JsonParser jsonParser;
+
+    @Mock
+    private DeserializationContext deserializationContext;
+
+    @Mock
+    private JsonMappingException jsonMappingException;
+
+    private MongoJackInstantDeserializer deserializer;
+
+    private Instant deserializedDate;
+
+    @Before
+    public void setUp() {
+        when(deserializationContext.mappingException(anyString())).thenReturn(jsonMappingException);
+        deserializer = new MongoJackInstantDeserializer();
+    }
+
+    @Test
+    public void testWithDateObject() throws IOException {
+        when(jsonParser.getCurrentTokenId()).thenReturn(JsonTokenId.ID_EMBEDDED_OBJECT);
+        when(jsonParser.getEmbeddedObject()).thenReturn(date);
+
+        deserializedDate = deserializer.deserialize(jsonParser, deserializationContext);
+        assertEquals(date.toInstant(), deserializedDate);
+    }
+
+    @Test
+    public void testWithInstantObject() throws IOException {
+        Instant instant = date.toInstant();
+        when(jsonParser.getCurrentTokenId()).thenReturn(JsonTokenId.ID_EMBEDDED_OBJECT);
+        when(jsonParser.getEmbeddedObject()).thenReturn(instant);
+
+        deserializedDate = deserializer.deserialize(jsonParser, deserializationContext);
+        assertEquals(instant, deserializedDate);
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void testWithoutDateObject() throws IOException {
+        when(jsonParser.getCurrentTokenId()).thenReturn(JsonTokenId.ID_EMBEDDED_OBJECT);
+        when(jsonParser.getEmbeddedObject()).thenReturn(new Object());
+
+        deserializedDate = deserializer.deserialize(jsonParser, deserializationContext);
+    }
+
+    @Test
+    public void testNoEmbeddedObject() throws IOException {
+        ObjectMapper mapper = createMapper();
+        deserializedDate = mapper.readValue(Long.toString(TIME_AS_LONG), Instant.class);
+        Instant instant = Instant.ofEpochSecond(TIME_AS_LONG);
+        assertEquals(instant, deserializedDate);
+    }
+
+    @Test(expected = JsonMappingException.class)
+    public void testDateIsNull() throws IOException {
+        when(jsonParser.getCurrentTokenId()).thenReturn(JsonTokenId.ID_NULL);
+        deserializedDate = deserializer.deserialize(jsonParser, deserializationContext);
+    }
+
+    private ObjectMapper createMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule(MongoJackInstantDeserializerTest.class.getSimpleName() + "Module");
+        module.addDeserializer(Instant.class, deserializer);
+        mapper.registerModule(module);
+        return mapper;
+    }
+}


### PR DESCRIPTION
For mongo `ISODate` objects `bson4jackson` puts instance of `java.util.Date` object into result json and marks it with `JsonTokenId.EMBEDDED_OBJECT`.
Jackson Instant deserializer expects it to be `Temporal` and falls with exception `java.lang.ClassCastException: class java.util.Date cannot be cast to class java.time.temporal.Temporal`
Current patch catches that exception and converts Date to Instant manually