### PR TITLE
Let JacksonMongoCollectionBuilder be reused

### DIFF
--- a/src/main/java/org/mongojack/JacksonMongoCollection.java
+++ b/src/main/java/org/mongojack/JacksonMongoCollection.java
@@ -1228,25 +1228,25 @@ public class JacksonMongoCollection<T> {
      * Creates builder to build {@link JacksonMongoCollection}.
      * @return created builder
      */
-    public static <T> JacksonMongoCollectionBuilder<T> builder() {
-        return new JacksonMongoCollectionBuilder<T>();
+    public static JacksonMongoCollectionBuilder builder() {
+        return new JacksonMongoCollectionBuilder();
     }
 
     /**
      * Builder to build {@link JacksonMongoCollection}.
      */
-    public static final class JacksonMongoCollectionBuilder<T> {
+    public static final class JacksonMongoCollectionBuilder {
         private ObjectMapper objectMapper;
         private Class<?> view;
 
         private JacksonMongoCollectionBuilder() {}
 
-        public JacksonMongoCollectionBuilder<T> withObjectMapper(ObjectMapper objectMapper) {
+        public JacksonMongoCollectionBuilder withObjectMapper(ObjectMapper objectMapper) {
             this.objectMapper = objectMapper;
             return this;
         }
 
-        public JacksonMongoCollectionBuilder<T> withView(Class<?> view) {
+        public JacksonMongoCollectionBuilder withView(Class<?> view) {
             this.view = view;
             return this;
         }
@@ -1258,8 +1258,8 @@ public class JacksonMongoCollection<T> {
          * @param valueType - The type that this should serialize and deserialize to.
          * @return A new instance of a JacksonMongoCollection
          */
-        public JacksonMongoCollection<T> build(com.mongodb.client.MongoCollection<?> mongoCollection, Class<T> valueType) {
-            return new JacksonMongoCollection<T>(mongoCollection, this.objectMapper, valueType, view);
+        public <E> JacksonMongoCollection<E> build(com.mongodb.client.MongoCollection<?> mongoCollection, Class<E> valueType) {
+            return new JacksonMongoCollection<>(mongoCollection, this.objectMapper, valueType, view);
         }
     }
 }

--- a/src/test/java/org/mongojack/TestJacksonMongoCollection.java
+++ b/src/test/java/org/mongojack/TestJacksonMongoCollection.java
@@ -38,7 +38,7 @@ public class TestJacksonMongoCollection extends MongoDBTestBase {
 
     @Before
     public void setup() throws Exception {
-        coll = JacksonMongoCollection.<MockObject> builder().build(getMongoCollection("testJacksonMongoCollection"), MockObject.class);
+        coll = JacksonMongoCollection.builder().build(getMongoCollection("testJacksonMongoCollection"), MockObject.class);
     }
 
     @Test

--- a/src/test/java/org/mongojack/TestJacksonMongoCollectionCustomObjectMapper.java
+++ b/src/test/java/org/mongojack/TestJacksonMongoCollectionCustomObjectMapper.java
@@ -16,27 +16,21 @@
  */
 package org.mongojack;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-
-import java.io.IOException;
-
 import org.bson.Document;
 import org.junit.Before;
 import org.junit.Test;
 import org.mongojack.internal.MongoJackModule;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 public class TestJacksonMongoCollectionCustomObjectMapper extends MongoDBTestBase {
 
@@ -44,7 +38,7 @@ public class TestJacksonMongoCollectionCustomObjectMapper extends MongoDBTestBas
 
     @Before
     public void setUp() {
-        coll = JacksonMongoCollection.<MockObject> builder()
+        coll = JacksonMongoCollection.builder()
             .withObjectMapper(createObjectMapper())
             .build(getMongoCollection("testJacksonMongoCollection"), MockObject.class);
     }

--- a/src/test/java/org/mongojack/TestJacksonMongoCollectionMultiple.java
+++ b/src/test/java/org/mongojack/TestJacksonMongoCollectionMultiple.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2011 VZ Netzwerke Ltd
+ * Copyright 2014 devbliss GmbH
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongojack;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class TestJacksonMongoCollectionMultiple extends MongoDBTestBase {
+
+    private JacksonMongoCollection.JacksonMongoCollectionBuilder builder;
+
+    public static class MockObject1 {
+        @Id
+        @ObjectId
+        public String id;
+        public Integer num;
+    }
+
+    public static class MockObject2 {
+        @Id
+        @ObjectId
+        public String id;
+        public String value;
+    }
+
+    @Before
+    public void setup() throws Exception {
+        builder = JacksonMongoCollection.builder();
+    }
+
+    @Test
+    public void testGetMultipleCollections() {
+        JacksonMongoCollection<MockObject1> coll1 =
+            builder.build(getMongoCollection("testJacksonMongoCollection1"), MockObject1.class);
+        JacksonMongoCollection<MockObject2> coll2 =
+            builder.build(getMongoCollection("testJacksonMongoCollection2"), MockObject2.class);
+
+        MockObject1 o1 = new MockObject1();
+        o1.num = 10;
+        MockObject2 o2 = new MockObject2();
+        o2.value = "test-2";
+        coll1.insert(o1);
+        coll2.insert(o2);
+
+        List<MockObject1> results11 = coll1
+                .find(new Document("num", 10)).into(new ArrayList<>());
+        assertThat(results11, hasSize(1));
+
+        List<MockObject1> results10 = coll1
+            .find(new Document("value", "test-2")).into(new ArrayList<>());
+        assertThat(results10, hasSize(0));
+
+        List<MockObject2> results21 = coll2
+            .find(new Document("value", "test-2")).into(new ArrayList<>());
+        assertThat(results21, hasSize(1));
+
+        List<MockObject2> results20 = coll2
+            .find(new Document("num", 10)).into(new ArrayList<>());
+        assertThat(results20, hasSize(0));
+    }
+}

--- a/src/test/java/org/mongojack/TestJacksonMongoCollectionMultiple.java
+++ b/src/test/java/org/mongojack/TestJacksonMongoCollectionMultiple.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2011 VZ Netzwerke Ltd
  * Copyright 2014 devbliss GmbH
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,20 +30,6 @@ public class TestJacksonMongoCollectionMultiple extends MongoDBTestBase {
 
     private JacksonMongoCollection.JacksonMongoCollectionBuilder builder;
 
-    public static class MockObject1 {
-        @Id
-        @ObjectId
-        public String id;
-        public Integer num;
-    }
-
-    public static class MockObject2 {
-        @Id
-        @ObjectId
-        public String id;
-        public String value;
-    }
-
     @Before
     public void setup() throws Exception {
         builder = JacksonMongoCollection.builder();
@@ -64,7 +50,7 @@ public class TestJacksonMongoCollectionMultiple extends MongoDBTestBase {
         coll2.insert(o2);
 
         List<MockObject1> results11 = coll1
-                .find(new Document("num", 10)).into(new ArrayList<>());
+            .find(new Document("num", 10)).into(new ArrayList<>());
         assertThat(results11, hasSize(1));
 
         List<MockObject1> results10 = coll1
@@ -78,5 +64,19 @@ public class TestJacksonMongoCollectionMultiple extends MongoDBTestBase {
         List<MockObject2> results20 = coll2
             .find(new Document("num", 10)).into(new ArrayList<>());
         assertThat(results20, hasSize(0));
+    }
+
+    public static class MockObject1 {
+        @Id
+        @ObjectId
+        public String id;
+        public Integer num;
+    }
+
+    public static class MockObject2 {
+        @Id
+        @ObjectId
+        public String id;
+        public String value;
     }
 }


### PR DESCRIPTION
I removed JacksonMongoCollectionBuilder generics, and changed 'build()' method for creating new JacksonMongoCollection for different collections with different document object types. So you can create only JacksonMongoCollectionBuilder for any type of collection. 

I'd added a new test as an example.