### PR TITLE
Serialize Instant to BSON datetime when possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,6 +420,15 @@
         <role>developer</role>
       </roles>
     </contributor>
+    <contributor>
+      <name>Vladimir Petrakovich</name>
+      <url>https://github.com/frost13it</url>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <organization>SKB Kontur</organization>
+      <organizationUrl>https://kontur-inc.com/</organizationUrl>
+    </contributor>
   </contributors>
 
   <licenses>

--- a/src/main/java/org/mongojack/internal/MongoJackInstantSerializer.java
+++ b/src/main/java/org/mongojack/internal/MongoJackInstantSerializer.java
@@ -1,0 +1,33 @@
+package org.mongojack.internal;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
+import org.mongojack.internal.stream.DBEncoderBsonGenerator;
+
+import java.io.IOException;
+import java.time.Instant;
+
+/**
+ * Serialises {@link Instant}s as BSON dates when nanosecond precision is disabled.
+ *
+ * <p>Requires support in {@link JsonGenerator} implementation (see {@link DBEncoderBsonGenerator}).</p>
+ *
+ * @author Vladimir Petrakovich
+ *
+ * @see SerializationFeature#WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS
+ */
+public class MongoJackInstantSerializer extends EmbeddedObjectSerializer<Instant> {
+
+    private final InstantSerializer defaultSerializer = InstantSerializer.INSTANCE;
+
+    @Override
+    public void serialize(Instant value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        if (provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+            defaultSerializer.serialize(value, jgen, provider);
+        } else {
+            super.serialize(value, jgen, provider);
+        }
+    }
+}

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -44,10 +44,11 @@ public class MongoJackModule extends Module {
      * @return This object mapper (for chaining)
      */
     public static ObjectMapper configure(ObjectMapper objectMapper) {
-        objectMapper.registerModule(INSTANCE);
-
-        // register java time module
+        // register java.time module before MongoJack
+        // to override its serializers and deserializers
         objectMapper.registerModule(JAVATIME);
+
+        objectMapper.registerModule(INSTANCE);
 
         // disable serialize dates as timestamps because we have fewer runtime errors that way
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);

--- a/src/main/java/org/mongojack/internal/MongoJackSerializers.java
+++ b/src/main/java/org/mongojack/internal/MongoJackSerializers.java
@@ -19,6 +19,7 @@ package org.mongojack.internal;
 import com.fasterxml.jackson.databind.module.SimpleSerializers;
 import org.bson.types.ObjectId;
 
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
@@ -36,6 +37,7 @@ public class MongoJackSerializers extends SimpleSerializers {
         addSerializer(ObjectId.class, new ObjectIdSerializer());
         addSerializer(Date.class, new DateSerializer());
         addSerializer(Calendar.class, new CalendarSerializer());
+        addSerializer(Instant.class, new MongoJackInstantSerializer());
         addSerializer(UUID.class, new UUIDSerializer());
     }
 }

--- a/src/main/java/org/mongojack/internal/stream/DBEncoderBsonGenerator.java
+++ b/src/main/java/org/mongojack/internal/stream/DBEncoderBsonGenerator.java
@@ -25,6 +25,7 @@ import org.bson.types.ObjectId;
 import org.mongojack.internal.util.DocumentSerializationUtils;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
@@ -49,6 +50,8 @@ public class DBEncoderBsonGenerator extends JsonGeneratorAdapter {
             writer.writeDateTime(((Date) value).getTime());
         } else if (value instanceof Calendar) {
             writer.writeDateTime(((Calendar) value).getTime().getTime());
+        } else if (value instanceof Instant) {
+            writer.writeDateTime(((Instant) value).toEpochMilli());
         } else if (value instanceof ObjectId) {
             writeBsonObjectId((ObjectId) value);
         } else if (value instanceof UUID) {


### PR DESCRIPTION
For now, only `java.util.Date` can be serialized to native BSON datetime. This PR makes `Instant` serializable in this format as well.
But doing so can lead to a loss of precision, so it is performed only when `SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS` is disabled. Otherwise `Instant` is serialized the same way as before.