### PR TITLE
Make javax persistence optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
       <version>2.2</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -428,6 +429,13 @@
       </roles>
       <organization>SKB Kontur</organization>
       <organizationUrl>https://kontur-inc.com/</organizationUrl>
+    </contributor>
+    <contributor>
+      <name>Stéphane Démurget</name>
+      <url>https://github.com/zzrough</url>
+      <roles>
+        <role>developer</role>
+      </roles>
     </contributor>
   </contributors>
 

--- a/src/main/java/org/mongojack/internal/AnnotationHelper.java
+++ b/src/main/java/org/mongojack/internal/AnnotationHelper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Stéphane Démurget
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongojack.internal;
+
+import org.mongojack.Id;
+
+import com.fasterxml.jackson.databind.introspect.Annotated;
+
+/**
+ * Helper to deal with annotations.
+ *
+ * @author Stéphane Démurget
+ */
+public class AnnotationHelper {
+
+    private static final Class<?> JAVAX_PERSIST_ID_CLASS = initJavaxPersistIdClass();
+
+    private AnnotationHelper() {
+        super();
+    }
+
+    public static boolean hasIdAnnotation(Annotated annotated) {
+        return annotated.hasAnnotation(Id.class) ||
+                (JAVAX_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAVAX_PERSIST_ID_CLASS));
+    }
+
+    private static Class<?> initJavaxPersistIdClass() {
+        try {
+            return Class.forName("javax.persistence.Id");
+        } catch (ClassNotFoundException e) {
+            return null; // javax persist @Id will not be supported
+        }
+    }
+}

--- a/src/main/java/org/mongojack/internal/MongoAnnotationIntrospector.java
+++ b/src/main/java/org/mongojack/internal/MongoAnnotationIntrospector.java
@@ -17,7 +17,6 @@
 package org.mongojack.internal;
 
 import org.mongojack.DBRef;
-import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import com.fasterxml.jackson.databind.JavaType;
@@ -67,11 +66,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
 
     private String findPropertyName(Annotated annotated) {
 
-        if (annotated.hasAnnotation(Id.class)
-                || annotated.hasAnnotation(javax.persistence.Id.class)) {
-            return "_id";
-        }
-        return null;
+        return AnnotationHelper.hasIdAnnotation(annotated) ? "_id" : null;
     }
 
     private Type getTypeForAnnotated(Annotated a) {

--- a/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
@@ -24,7 +24,7 @@ import org.bson.codecs.EncoderContext;
 import org.bson.codecs.OverridableUuidRepresentationCodec;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
-import org.mongojack.Id;
+import org.mongojack.internal.AnnotationHelper;
 
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -189,9 +189,9 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
 
                 final Optional<BeanPropertyDefinition> found = beanDescription.findProperties().stream()
                     .filter(
-                        bpd -> (bpd.getPrimaryMember().hasAnnotation(Id.class) ||
-                            bpd.getPrimaryMember().hasAnnotation(javax.persistence.Id.class) ||
-                            "_id".equals(bpd.getName())) && bpd.getAccessor() != null
+                        bpd -> ("_id".equals(bpd.getName()) ||
+                                AnnotationHelper.hasIdAnnotation(bpd.getPrimaryMember())) &&
+                                bpd.getAccessor() != null
                     )
                     .findFirst();
 
@@ -217,9 +217,9 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
 
                 final Optional<BeanPropertyDefinition> found = beanDescription.findProperties().stream()
                     .filter(
-                        bpd -> (bpd.getPrimaryMember().hasAnnotation(Id.class) ||
-                            bpd.getPrimaryMember().hasAnnotation(javax.persistence.Id.class) ||
-                            "_id".equals(bpd.getName())) && bpd.getMutator() != null
+                        bpd -> ("_id".equals(bpd.getName()) ||
+                                AnnotationHelper.hasIdAnnotation(bpd.getPrimaryMember())) &&
+                                bpd.getMutator() != null
                     )
                     .findFirst();
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -27,7 +27,7 @@ Features
 * Can be used purely as a codec for a MongoCollection, or provides a wrapper collection that implements all MongoCollection functionality.
 * Provides all MongoDB MongoCollection features.
 * Supports mapping ObjectIds to strings and byte arrays, using an `@ObjectID` annotation.
-* Supports `@javax.persistance.Id` annotation for marking which property is the id (or just call it `_id`).
+* Supports `@javax.persistance.Id` annotation for marking which property is the id (if JPA is available - optional dependency) or just call it `_id`.
 * Maps POJOs provided in query or update Bson documents
 * Supports database reference conventions, with convenience functionality for fetching references and collections of references in one query.
 


### PR DESCRIPTION
There's no real reason to pull JPA just for the javax.persistence.Id annotation.
This PR makes the dependency optional and add an helper to avoid some copy/paste.