### PR TITLE
Fix for #220 - Filters.regexp not working

### DIFF
--- a/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsImpl.java
+++ b/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsImpl.java
@@ -499,6 +499,8 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
                 serializer = findQuerySerializer(targetIsCollection, key, serializerProvider, serializer);
             }
             serializeFilter(serializerProvider, serializer, (Map<String, Object>) condition, writer, generator);
+        } else if (condition instanceof Pattern) {
+            writer.writeRegularExpression(new BsonRegularExpression(((Pattern) condition).pattern()));
         } else {
             if (keyIsNotOperator(key)) {
                 serializer = findQuerySerializer(false, key, serializerProvider, serializer);

--- a/src/test/java/org/mongojack/TestQuerySerialization.java
+++ b/src/test/java/org/mongojack/TestQuerySerialization.java
@@ -333,6 +333,26 @@ public class TestQuerySerialization extends MongoDBTestBase {
         assertEquals(o1.id, coll.find().filter(Filters.regex("wrappedStringList", "foo:.*")).first().id);
     }
 
+    @SuppressWarnings({"ConstantConditions", "unchecked"})
+    @Test
+    public void testSearchWithPatternFilter() {
+        MockObject o1 = new MockObject();
+        o1.text = "foo:bar";
+        MockObject o2 = new MockObject();
+        o2.genericMap = Collections.singletonMap("ref", "baz:qux");
+        coll.insertMany(Arrays.asList(o1, o2));
+
+        assertEquals(o1.id, coll.find(DBQuery.regex("text", Pattern.compile("foo:.*"))).first().id);
+        assertEquals(o1.id, coll.find().filter(DBQuery.regex("text", Pattern.compile("foo:.*"))).first().id);
+        assertEquals(o2.id, coll.find(DBQuery.regex("genericMap.ref", Pattern.compile("baz:.*"))).first().id);
+        assertEquals(o2.id, coll.find().filter(DBQuery.regex("genericMap.ref", Pattern.compile("baz:.*"))).first().id);
+
+        assertEquals(o1.id, coll.find(Filters.regex("text", Pattern.compile("foo:.*"))).first().id);
+        assertEquals(o1.id, coll.find().filter(Filters.regex("text", Pattern.compile("foo:.*"))).first().id);
+        assertEquals(o2.id, coll.find(Filters.regex("genericMap.ref", Pattern.compile("baz:.*"))).first().id);
+        assertEquals(o2.id, coll.find().filter(Filters.regex("genericMap.ref", Pattern.compile("baz:.*"))).first().id);
+    }
+
     static class MockObject {
         @ObjectId
         @Id
@@ -347,6 +367,9 @@ public class TestQuerySerialization extends MongoDBTestBase {
         public WrappedString wrappedString;
 
         public List<WrappedString> wrappedStringList;
+
+        public String text;
+        public Map<String,Object> genericMap;
     }
 
     static class MockEmbedded {


### PR DESCRIPTION
For Map-based embedded docs, Filters.regexp is not working where
DBQuery.regexp is being fine.

* Filters.regexp("field", Pattern.compile("^[0-9]")) is fine
  (serialized to a regexp doc)
* Filters.regexp("field.subfield", Pattern.compile("^[0-9]")) is NOT working
  (serialized to a string) (field being a generic Map<String,Object> in java)

At runtime DocumentSerializationUtilsImpl#serializeFilter loses the Pattern
type information because we get a MapSerializer then a ToStringSerializer and
the db query sent to the server is thus wrong.