### PR TITLE
Fix NPE caused by fields with WRITE_ONLY access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,13 @@
         <role>developer</role>
       </roles>
     </contributor>
+    <contributor>
+      <name>Volodymyr Masliy</name>
+      <url>https://github.com/skipua</url>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </contributor>
   </contributors>
 
   <licenses>

--- a/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
@@ -216,6 +216,7 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
                 final BeanDescription beanDescription = serializationConfig.introspect(serializationConfig.constructType(documentClass));
 
                 final Optional<BeanPropertyDefinition> found = beanDescription.findProperties().stream()
+                    .filter(bpd -> bpd.getPrimaryMember() != null)
                     .filter(
                         bpd -> ("_id".equals(bpd.getName()) ||
                                 AnnotationHelper.hasIdAnnotation(bpd.getPrimaryMember())) &&

--- a/src/test/java/org/mongojack/mock/MockObjectWithWriteReadOnlyFields.java
+++ b/src/test/java/org/mongojack/mock/MockObjectWithWriteReadOnlyFields.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2011 VZ Netzwerke Ltd
+ * Copyright 2014 devbliss GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongojack.mock;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Used to test READ_ONLY (only for serialization) and WRITE_ONLY (only for deserialization) fields
+ *
+ * @author Volodymyr Masliy
+ */
+public class MockObjectWithWriteReadOnlyFields {
+    private String _id;
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private String someReadOnlyField;
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String someWriteOnlyField;
+
+    public MockObjectWithWriteReadOnlyFields() {
+    }
+
+    public MockObjectWithWriteReadOnlyFields(String _id, String someReadOnlyField, String someWriteOnlyField) {
+        this._id = _id;
+        this.someReadOnlyField = someReadOnlyField;
+        this.someWriteOnlyField = someWriteOnlyField;
+    }
+
+    public String get_id() {
+        return _id;
+    }
+
+    public void set_id(String _id) {
+        this._id = _id;
+    }
+
+    public String getSomeReadOnlyField() {
+        return someReadOnlyField;
+    }
+
+    public void setSomeReadOnlyField(String someReadOnlyField) {
+        this.someReadOnlyField = someReadOnlyField;
+    }
+
+    public String getSomeWriteOnlyField() {
+        return someWriteOnlyField;
+    }
+
+    public void setSomeWriteOnlyField(String someWriteOnlyField) {
+        this.someWriteOnlyField = someWriteOnlyField;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MockObjectWithWriteReadOnlyFields that = (MockObjectWithWriteReadOnlyFields) o;
+        return Objects.equals(_id, that._id) && Objects.equals(someReadOnlyField, that.someReadOnlyField) && Objects.equals(
+            someWriteOnlyField, that.someWriteOnlyField);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_id, someReadOnlyField, someWriteOnlyField);
+    }
+
+    @Override
+    public String toString() {
+        return "SampleWithWriteOnly{" +
+            "_id='" + _id + '\'' +
+            ", someReadOnlyField='" + someReadOnlyField + '\'' +
+            ", someWriteOnlyField='" + someWriteOnlyField + '\'' +
+            '}';
+    }
+}


### PR DESCRIPTION
NullPointerException is thrown during insert when any field marked with 
`@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)`:

`
java.lang.NullPointerException
	at org.mongojack.internal.AnnotationHelper.hasIdAnnotation(AnnotationHelper.java:36)
	at org.mongojack.internal.stream.JacksonCodec.lambda$getIdElementSerializationDescription$11(JacksonCodec.java:221)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:176)
`

This happens because `POJOPropertyBuilder::getPrimaryMember` in case of serialization returns null when field is meant for deseriazliation only (according to WRITE_ONLY annotation)


Here is reproducer: https://github.com/Skipua/mongojack-jackson-writeonly-issue