### PR TITLE
Support for mongodb driver 4.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Quick start
 - Version 4.3.x is built on the master branch against MongoDB's 4.3.x driver
 - Version 4.5.x is built on the master branch against MongoDB's 4.5.x driver
 - Version 4.7.x is built on the master branch against MongoDB's 4.7.x driver
+- Version 4.8.x is built on the master branch against MongoDB's 4.8.x driver
 
 ### Installation
 
@@ -45,12 +46,12 @@ Maven:
     <dependency>
       <groupId>org.mongojack</groupId>
       <artifactId>mongojack</artifactId>
-      <version>4.7.0</version>
+      <version>4.8.0</version>
     </dependency>
 
 Gradle:
 
-    implementation 'org.mongojack:mongojack:4.7.0'
+    implementation 'org.mongojack:mongojack:4.8.0'
 
 ### Writing code
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.mongojack</groupId>
   <artifactId>mongojack</artifactId>
-  <version>4.7.1-SNAPSHOT</version>
+  <version>4.8.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>MongoJack</name>
@@ -20,7 +20,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.14.1</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-sync</artifactId>
-      <version>4.7.0</version>
+      <version>4.8.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -45,6 +45,12 @@
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
       <version>2.2</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>3.1.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/org/mongojack/Id.java
+++ b/src/main/java/org/mongojack/Id.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Basically the same as {@link javax.persistence.Id}, but allows placement on params as well, for use when using
+ * Basically the same as {@link javax.persistence.Id} or {@link jakarta.persistence.Id}, but allows placement on params as well, for use when using
  * JsonCreator
  * 
  * @author James Roper

--- a/src/main/java/org/mongojack/internal/AnnotationHelper.java
+++ b/src/main/java/org/mongojack/internal/AnnotationHelper.java
@@ -26,7 +26,8 @@ import com.fasterxml.jackson.databind.introspect.Annotated;
  */
 public class AnnotationHelper {
 
-    private static final Class<?> JAVAX_PERSIST_ID_CLASS = initJavaxPersistIdClass();
+    private static final Class<?> JAVAX_PERSIST_ID_CLASS = initPersistIdClass("javax.persistence.Id");
+    private static final Class<?> JAKARTA_PERSIST_ID_CLASS = initPersistIdClass("jakarta.persistence.Id");
 
     private AnnotationHelper() {
         super();
@@ -34,14 +35,15 @@ public class AnnotationHelper {
 
     public static boolean hasIdAnnotation(Annotated annotated) {
         return annotated.hasAnnotation(Id.class) ||
-                (JAVAX_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAVAX_PERSIST_ID_CLASS));
+            (JAVAX_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAVAX_PERSIST_ID_CLASS)) ||
+            (JAKARTA_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAKARTA_PERSIST_ID_CLASS));
     }
 
-    private static Class<?> initJavaxPersistIdClass() {
+    private static Class<?> initPersistIdClass(String className) {
         try {
-            return Class.forName("javax.persistence.Id");
+            return Class.forName(className);
         } catch (ClassNotFoundException e) {
-            return null; // javax persist @Id will not be supported
+            return null; // javax or jakarta persist @Id will not be supported
         }
     }
 }

--- a/src/main/java/org/mongojack/internal/MongoAnnotationIntrospector.java
+++ b/src/main/java/org/mongojack/internal/MongoAnnotationIntrospector.java
@@ -42,7 +42,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
         this.typeFactory = typeFactory;
     }
 
-    // Handling of javax.persistence.Id
+    // Handling of javax.persistence.Id and jakarta.persistence.Id
     @Override
     public PropertyName findNameForDeserialization(Annotated a) {
 

--- a/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsImpl.java
+++ b/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsImpl.java
@@ -46,10 +46,11 @@ import org.bson.BsonValue;
 import org.bson.BsonWriter;
 import org.bson.Document;
 import org.bson.UuidRepresentation;
+import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
+import org.bson.codecs.UuidCodec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
-import org.bson.internal.OverridableUuidRepresentationCodecRegistry;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.mongojack.Aggregation;
@@ -455,8 +456,9 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
 
     protected UuidRepresentation attemptToExtractUuidRepresentation(final CodecRegistry registry) {
         UuidRepresentation uuidRepresentation = UuidRepresentation.STANDARD;
-        if (registry instanceof OverridableUuidRepresentationCodecRegistry) {
-            uuidRepresentation = ((OverridableUuidRepresentationCodecRegistry) registry).getUuidRepresentation();
+        Codec<UUID> uuidCodec = registry.get(UUID.class);
+        if (uuidCodec instanceof UuidCodec) {
+            uuidRepresentation = ((UuidCodec) uuidCodec).getUuidRepresentation();
         } else if (registry instanceof JacksonCodecRegistry) {
             uuidRepresentation = ((JacksonCodecRegistry) registry).getUuidRepresentation();
         }

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+4.8.0
+-----
+_Released 2023.xx.xx_
+
+* Upgrade to mongo driver version 4.8.0
+* Added support for javax.persistence.Id annotation
+
 4.7.0
 -----
 _Released 2022.07.22_

--- a/src/test/java/org/mongojack/TestIdAnnotatedClass.java
+++ b/src/test/java/org/mongojack/TestIdAnnotatedClass.java
@@ -53,18 +53,34 @@ public class TestIdAnnotatedClass extends MongoDBTestBase {
     }
 
     @Test
-    public void testJpaIdFieldAnnotated() {
-        JpaIdFieldAnnotated o = new JpaIdFieldAnnotated();
+    public void testJavaxJpaIdFieldAnnotated() {
+        JavaxJpaIdFieldAnnotated o = new JavaxJpaIdFieldAnnotated();
         o.id = "blah";
-        JacksonMongoCollection<JpaIdFieldAnnotated> coll = createCollFor(o);
+        JacksonMongoCollection<JavaxJpaIdFieldAnnotated> coll = createCollFor(o);
         coll.insert(o);
-        JpaIdFieldAnnotated result = coll.findOneById("blah");
+        JavaxJpaIdFieldAnnotated result = coll.findOneById("blah");
         assertThat(result, notNullValue());
         assertThat(result.id, equalTo("blah"));
     }
 
-    public static class JpaIdFieldAnnotated {
+    public static class JavaxJpaIdFieldAnnotated {
         @javax.persistence.Id
+        public String id;
+    }
+
+    @Test
+    public void testJakartaJpaIdFieldAnnotated() {
+        JakartaJpaIdFieldAnnotated o = new JakartaJpaIdFieldAnnotated();
+        o.id = "blah";
+        JacksonMongoCollection<JakartaJpaIdFieldAnnotated> coll = createCollFor(o);
+        coll.insert(o);
+        JakartaJpaIdFieldAnnotated result = coll.findOneById("blah");
+        assertThat(result, notNullValue());
+        assertThat(result.id, equalTo("blah"));
+    }
+
+    public static class JakartaJpaIdFieldAnnotated {
+        @jakarta.persistence.Id
         public String id;
     }
 


### PR DESCRIPTION
Added workaround to provide compatibility with latest `mongodb-driver-sync` version 4.8.x from which was removed `OverridableUuidRepresentationCodecRegistry`. Compatibility with `mongodb-driver-sync` version 4.7.x and older should remain intact.

Additionally added support for Jakarta Persistence API as many libraries and frameworks are switching from Javax dependencies with Jakarta.