### PR TITLE
added support for the BsonId annotation from mongo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,14 @@
         <role>developer</role>
       </roles>
     </contributor>
+    <contributor>
+      <name>Jamie de Leest</name>
+      <email>jdeleest@live.nl</email>
+      <url>https://github.com/The0Danktor</url>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </contributor>
   </contributors>
 
   <licenses>

--- a/src/main/java/org/mongojack/internal/AnnotationHelper.java
+++ b/src/main/java/org/mongojack/internal/AnnotationHelper.java
@@ -28,6 +28,7 @@ public class AnnotationHelper {
 
     private static final Class<?> JAVAX_PERSIST_ID_CLASS = initPersistIdClass("javax.persistence.Id");
     private static final Class<?> JAKARTA_PERSIST_ID_CLASS = initPersistIdClass("jakarta.persistence.Id");
+    private static final Class<?> BSON_PERSIST_ID_CLASS = initPersistIdClass("org.bson.codecs.pojo.annotations.BsonId");
 
     private AnnotationHelper() {
         super();
@@ -36,7 +37,8 @@ public class AnnotationHelper {
     public static boolean hasIdAnnotation(Annotated annotated) {
         return annotated.hasAnnotation(Id.class) ||
             (JAVAX_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAVAX_PERSIST_ID_CLASS)) ||
-            (JAKARTA_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAKARTA_PERSIST_ID_CLASS));
+            (JAKARTA_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAKARTA_PERSIST_ID_CLASS))||
+            (BSON_PERSIST_ID_CLASS != null && annotated.hasAnnotation(BSON_PERSIST_ID_CLASS));
     }
 
     private static Class<?> initPersistIdClass(String className) {

--- a/src/test/java/org/mongojack/TestIdAnnotatedClass.java
+++ b/src/test/java/org/mongojack/TestIdAnnotatedClass.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.mongodb.client.model.Filters;
 import org.bson.Document;
+import org.bson.codecs.pojo.annotations.BsonId;
 import org.junit.Test;
 import org.mongojack.internal.MongoJackModule;
 import org.mongojack.mock.IdProxy;
@@ -81,6 +82,22 @@ public class TestIdAnnotatedClass extends MongoDBTestBase {
 
     public static class JakartaJpaIdFieldAnnotated {
         @jakarta.persistence.Id
+        public String id;
+    }
+
+    @Test
+    public void testBsonIdFieldAnnotated() {
+        BsonIdFieldAnnotated o = new BsonIdFieldAnnotated();
+        o.id = "blah";
+        JacksonMongoCollection<BsonIdFieldAnnotated> coll = createCollFor(o);
+        coll.insert(o);
+        BsonIdFieldAnnotated result = coll.findOneById("blah");
+        assertThat(result, notNullValue());
+        assertThat(result.id, equalTo("blah"));
+    }
+
+    public static class BsonIdFieldAnnotated {
+        @BsonId
         public String id;
     }
 


### PR DESCRIPTION
im currently working on a project that is miggration from a deprecated mongodb libary that uses jackson for serilization and deserilization to mongojack, but that libary had support for `@BsonId` annotation so it used everywhere and i thought it would be also nice addition for mongojack