### PR TITLE
In the idWriter, try setter before mutator/constructor

### DIFF
--- a/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
@@ -124,11 +124,7 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
         return maybeBpd.<Consumer<BsonObjectId>>map(beanPropertyDefinition -> (bsonObjectId) -> {
             try {
                 if (bsonObjectId != null) {
-                    AnnotatedMember member = beanPropertyDefinition.getSetter();
-                    if (member == null) {
-                        member = beanPropertyDefinition.getMutator();
-                    }
-                    member.setValue(
+                    beanPropertyDefinition.getNonConstructorMutator().setValue(
                         t,
                         extractIdValue(bsonObjectId, beanPropertyDefinition.getRawPrimaryType())
                     );

--- a/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
+import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import org.bson.BsonDecimal128;
 import org.bson.BsonDocument;
@@ -121,7 +124,11 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
         return maybeBpd.<Consumer<BsonObjectId>>map(beanPropertyDefinition -> (bsonObjectId) -> {
             try {
                 if (bsonObjectId != null) {
-                    beanPropertyDefinition.getMutator().setValue(
+                    AnnotatedMember member = beanPropertyDefinition.getSetter();
+                    if (member == null) {
+                        member = beanPropertyDefinition.getMutator();
+                    }
+                    member.setValue(
                         t,
                         extractIdValue(bsonObjectId, beanPropertyDefinition.getRawPrimaryType())
                     );

--- a/src/test/java/org/mongojack/TestObjectIdHandling.java
+++ b/src/test/java/org/mongojack/TestObjectIdHandling.java
@@ -16,8 +16,7 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.*;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
@@ -537,6 +536,43 @@ public class TestObjectIdHandling extends MongoDBTestBase {
         @Id
         public UUID _id;
 
+    }
+
+    @Test
+    public void testObjectIdWithNoSetterSaved() {
+        ObjectWithConstructorOnlyObjectId object = new ObjectWithConstructorOnlyObjectId(null);
+
+        JacksonMongoCollection<ObjectWithConstructorOnlyObjectId> coll = getCollection(ObjectWithConstructorOnlyObjectId.class);
+
+        coll.insert(object);
+
+        assertThat(object.getId()).isNotNull();
+
+        ObjectWithConstructorOnlyObjectId result = coll.findOne();
+        assertThat(result.getId()).isNotNull();
+    }
+
+    public static class ObjectWithConstructorOnlyObjectId {
+
+        @JsonIgnore
+        private ObjectId id;
+
+        @JsonCreator
+        public ObjectWithConstructorOnlyObjectId(@Id  ObjectId id) {
+            this.id = id;
+        }
+
+        @JsonGetter
+        @Id
+        public ObjectId getId() {
+            return id;
+        }
+
+        @JsonSetter
+        @Id
+        public void setId(ObjectId id) {
+            this.id = id;
+        }
     }
 
 }


### PR DESCRIPTION
This PR adds code to the `idWriter` to get the setter before trying the mutator. When using Kotlin data classes, the mutator returns the constructor which cannot be used to set the property.

For example, when using a class structure like:
```
interface DbObject {
    var _id: ObjectId?
}

data class Model(
    override var _id: ObjectId? = null,
    var value: String = ""
): DbObject
````

things break down when the code is trying to set the generated `_id` value: `getMutator` returns the constructor value which doesn't support setting it. Instead, `getSetter` can be used here, but apparently only when using Kotlin data classes.

I have been able to test this locally, but I didn't know how to include a useful unit test, because that would require adding Kotlin support to the project.