### PR TITLE
Upgrade to Jackson 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
+        <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.16.1</version>
+        <version>3.0.4</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -41,12 +41,8 @@
       <version>5.6.2</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -138,8 +134,8 @@
         <version>3.13.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
-          <source>11</source>
-          <target>11</target>
+          <source>17</source>
+          <target>17</target>
           <compilerArgument>-Xlint:deprecation</compilerArgument>
           <showDeprecation>true</showDeprecation>
         </configuration>

--- a/src/main/java/org/mongojack/DBRef.java
+++ b/src/main/java/org/mongojack/DBRef.java
@@ -49,14 +49,14 @@ public class DBRef<T, K> {
      *
      * @param id   The id of the database reference to construct
      * @param type The type of the object
-     * @throws MongoJsonMappingException If no MongoCollection annotation is found on the type
+     * @throws MongoDatabindException If no MongoCollection annotation is found on the type
      */
-    public DBRef(K id, Class<T> type) throws MongoJsonMappingException {
+    public DBRef(K id, Class<T> type) throws MongoDatabindException {
         this.id = id;
         this.objectClass = type;
         MongoCollection collection = type.getAnnotation(MongoCollection.class);
         if (collection == null) {
-            throw new MongoJsonMappingException("Only types that have the @MongoCollection annotation on them can be used with this constructor");
+            throw new MongoDatabindException("Only types that have the @MongoCollection annotation on them can be used with this constructor");
         }
         this.collectionName = collection.name();
         this.databaseName = null;

--- a/src/main/java/org/mongojack/DbReferenceManager.java
+++ b/src/main/java/org/mongojack/DbReferenceManager.java
@@ -1,6 +1,6 @@
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import org.bson.UuidRepresentation;

--- a/src/main/java/org/mongojack/InitializationRequiredForTransformation.java
+++ b/src/main/java/org/mongojack/InitializationRequiredForTransformation.java
@@ -1,7 +1,7 @@
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
 import org.mongojack.JacksonCodecRegistry;
 
 public interface InitializationRequiredForTransformation {

--- a/src/main/java/org/mongojack/JacksonCodecRegistry.java
+++ b/src/main/java/org/mongojack/JacksonCodecRegistry.java
@@ -1,6 +1,6 @@
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.mongodb.DBObject;
 import com.mongodb.client.model.mql.MqlValue;
 import org.bson.BsonValue;

--- a/src/main/java/org/mongojack/JacksonMongoCollection.java
+++ b/src/main/java/org/mongojack/JacksonMongoCollection.java
@@ -16,9 +16,9 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.introspect.BeanPropertyDefinition;
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoWriteConcernException;

--- a/src/main/java/org/mongojack/MongoDatabindException.java
+++ b/src/main/java/org/mongojack/MongoDatabindException.java
@@ -16,9 +16,9 @@
  */
 package org.mongojack;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
+import tools.jackson.databind.DatabindException;
 import com.mongodb.MongoException;
 
 /**
@@ -28,21 +28,21 @@ import com.mongodb.MongoException;
  * @author James Roper
  * @since 1.0
  */
-public class MongoJsonMappingException extends MongoException {
+public class MongoDatabindException extends MongoException {
 
-    public MongoJsonMappingException(String msg) {
+    public MongoDatabindException(String msg) {
         super(msg);
     }
 
-    public MongoJsonMappingException(JsonMappingException e) {
+    public MongoDatabindException(DatabindException e) {
         super("Error mapping BSON to POJOs", e);
     }
 
-    public MongoJsonMappingException(String msg, JsonMappingException e) {
+    public MongoDatabindException(String msg, DatabindException e) {
         super(msg, e);
     }
 
-    public MongoJsonMappingException(String msg, IOException e) {
+    public MongoDatabindException(String msg, JacksonException e) {
         super(msg, e);
     }
 

--- a/src/main/java/org/mongojack/MongoJackModuleConfiguration.java
+++ b/src/main/java/org/mongojack/MongoJackModuleConfiguration.java
@@ -1,14 +1,18 @@
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.cfg.MapperConfig;
-
 @SuppressWarnings("unused")
 public class MongoJackModuleConfiguration {
 
     private final int moduleFeatures;
 
     public MongoJackModuleConfiguration() {
-        moduleFeatures = MapperConfig.collectFeatureDefaults(MongoJackModuleFeature.class);
+        int flags = 0;
+        for (MongoJackModuleFeature value : MongoJackModuleFeature.class.getEnumConstants()) {
+            if (value.enabledByDefault()) {
+                flags |= value.getMask();
+            }
+        }
+        moduleFeatures = flags;
     }
 
     public MongoJackModuleConfiguration(final int moduleFeatures) {
@@ -25,8 +29,7 @@ public class MongoJackModuleConfiguration {
      */
     public MongoJackModuleConfiguration with(MongoJackModuleFeature feature) {
         int newModuleFeatures = (moduleFeatures | feature.getMask());
-        return (newModuleFeatures == moduleFeatures) ? this :
-            new MongoJackModuleConfiguration(newModuleFeatures);
+        return (newModuleFeatures == moduleFeatures) ? this : new MongoJackModuleConfiguration(newModuleFeatures);
     }
 
     /**
@@ -34,15 +37,13 @@ public class MongoJackModuleConfiguration {
      * object instance with specified features enabled.
      */
     public MongoJackModuleConfiguration with(
-        MongoJackModuleFeature first,
-        MongoJackModuleFeature... features
-    ) {
+            MongoJackModuleFeature first,
+            MongoJackModuleFeature... features) {
         int newModuleFeatures = moduleFeatures | first.getMask();
         for (MongoJackModuleFeature f : features) {
             newModuleFeatures |= f.getMask();
         }
-        return (newModuleFeatures == moduleFeatures) ? this :
-            new MongoJackModuleConfiguration(newModuleFeatures);
+        return (newModuleFeatures == moduleFeatures) ? this : new MongoJackModuleConfiguration(newModuleFeatures);
     }
 
     /**
@@ -54,8 +55,7 @@ public class MongoJackModuleConfiguration {
         for (MongoJackModuleFeature f : features) {
             newModuleFeatures |= f.getMask();
         }
-        return (newModuleFeatures == moduleFeatures) ? this :
-            new MongoJackModuleConfiguration(newModuleFeatures);
+        return (newModuleFeatures == moduleFeatures) ? this : new MongoJackModuleConfiguration(newModuleFeatures);
     }
 
     /**
@@ -64,8 +64,7 @@ public class MongoJackModuleConfiguration {
      */
     public MongoJackModuleConfiguration without(MongoJackModuleFeature feature) {
         int newModuleFeatures = moduleFeatures & ~feature.getMask();
-        return (newModuleFeatures == moduleFeatures) ? this :
-            new MongoJackModuleConfiguration(newModuleFeatures);
+        return (newModuleFeatures == moduleFeatures) ? this : new MongoJackModuleConfiguration(newModuleFeatures);
     }
 
     /**
@@ -73,15 +72,13 @@ public class MongoJackModuleConfiguration {
      * object instance with specified features disabled.
      */
     public MongoJackModuleConfiguration without(
-        MongoJackModuleFeature first,
-        MongoJackModuleFeature... features
-    ) {
+            MongoJackModuleFeature first,
+            MongoJackModuleFeature... features) {
         int newModuleFeatures = moduleFeatures & ~first.getMask();
         for (MongoJackModuleFeature f : features) {
             newModuleFeatures &= ~f.getMask();
         }
-        return (newModuleFeatures == moduleFeatures) ? this :
-            new MongoJackModuleConfiguration(newModuleFeatures);
+        return (newModuleFeatures == moduleFeatures) ? this : new MongoJackModuleConfiguration(newModuleFeatures);
     }
 
     /**
@@ -93,8 +90,7 @@ public class MongoJackModuleConfiguration {
         for (MongoJackModuleFeature f : features) {
             newModuleFeatures &= ~f.getMask();
         }
-        return (newModuleFeatures == moduleFeatures) ? this :
-            new MongoJackModuleConfiguration(newModuleFeatures);
+        return (newModuleFeatures == moduleFeatures) ? this : new MongoJackModuleConfiguration(newModuleFeatures);
     }
 
 }

--- a/src/main/java/org/mongojack/MongoJackModuleFeature.java
+++ b/src/main/java/org/mongojack/MongoJackModuleFeature.java
@@ -1,6 +1,6 @@
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.cfg.ConfigFeature;
+import tools.jackson.databind.cfg.ConfigFeature;
 
 public enum MongoJackModuleFeature implements ConfigFeature {
 
@@ -23,7 +23,7 @@ public enum MongoJackModuleFeature implements ConfigFeature {
     /**
      * Serialises {@link java.time.Instant}s as BSON dates when nanosecond precision is disabled.
      *
-     * @see com.fasterxml.jackson.databind.SerializationFeature#WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS
+     * @see tools.jackson.databind.SerializationFeature#WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS
      */
     WRITE_INSTANT_AS_BSON_DATE(false),
 

--- a/src/main/java/org/mongojack/ObjectMapperConfigurer.java
+++ b/src/main/java/org/mongojack/ObjectMapperConfigurer.java
@@ -5,7 +5,7 @@ import org.mongojack.internal.MongoJackModule;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * Can be used by OSGi containers (or anyone else) to configure a custom ObjectMapper instance.  This is necessary
+ * Can be used by OSGi containers (or anyone else) to configure a custom ObjectMapper instance. This is necessary
  * because {@link org.mongojack.internal.MongoJackModule} is in the internal module, but it also can be used
  * by any caller to avoid using the "internal" implementations.
  */
@@ -16,7 +16,7 @@ public class ObjectMapperConfigurer {
     }
 
     /**
-     * Install the MongoJackModule into the object mapper with recommended settings.  Also installs JavaTimeModule.
+     * Install the MongoJackModule into the object mapper with recommended settings. Also installs JavaTimeModule.
      *
      * @param mapper
      * @return
@@ -26,7 +26,7 @@ public class ObjectMapperConfigurer {
     }
 
     /**
-     * Install the MongoJackModule into the object mapper with recommended settings.  Also installs JavaTimeModule.
+     * Install the MongoJackModule into the object mapper with recommended settings. Also installs JavaTimeModule.
      *
      * @param mapper
      * @return
@@ -42,8 +42,7 @@ public class ObjectMapperConfigurer {
      * @return
      */
     public static ObjectMapper addMongojackModuleOnly(ObjectMapper mapper) {
-        mapper.registerModule(MongoJackModule.DEFAULT_MODULE_INSTANCE);
-        return mapper;
+        return mapper.rebuild().addModule(MongoJackModule.DEFAULT_MODULE_INSTANCE).build();
     }
 
     /**
@@ -53,8 +52,7 @@ public class ObjectMapperConfigurer {
      * @return
      */
     public static ObjectMapper addMongojackModuleOnly(ObjectMapper mapper, MongoJackModuleConfiguration moduleConfiguration) {
-        mapper.registerModule(new MongoJackModule(moduleConfiguration));
-        return mapper;
+        return mapper.rebuild().addModule(new MongoJackModule(moduleConfiguration)).build();
     }
 
 }

--- a/src/main/java/org/mongojack/ObjectMapperConfigurer.java
+++ b/src/main/java/org/mongojack/ObjectMapperConfigurer.java
@@ -1,7 +1,8 @@
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.mongojack.internal.MongoJackModule;
+
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Can be used by OSGi containers (or anyone else) to configure a custom ObjectMapper instance.  This is necessary

--- a/src/main/java/org/mongojack/TransformingEmbeddedObjectSerializer.java
+++ b/src/main/java/org/mongojack/TransformingEmbeddedObjectSerializer.java
@@ -20,7 +20,6 @@ import org.mongojack.internal.stream.DBEncoderBsonGenerator;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
-import tools.jackson.core.TokenStreamContext;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 import tools.jackson.databind.util.TokenBuffer;
@@ -66,14 +65,11 @@ public abstract class TransformingEmbeddedObjectSerializer<InputType, Transforme
             }
         } else if (jgen instanceof TokenBuffer) {
             TokenBuffer buffer = (TokenBuffer) jgen;
-            TokenStreamContext codec = buffer.streamWriteContext();
-            buffer.overrideParentContext(null);
             if (value == null && writeNullAsNull) {
                 buffer.writeNull();
             } else {
-                buffer.writePOJO(value);
+                buffer.writeEmbeddedObject(value);
             }
-            buffer.overrideParentContext(codec);
         } else {
             String message = "JsonGenerator of type "
                     + jgen.getClass().getName()

--- a/src/main/java/org/mongojack/TransformingEmbeddedObjectSerializer.java
+++ b/src/main/java/org/mongojack/TransformingEmbeddedObjectSerializer.java
@@ -66,28 +66,28 @@ public abstract class TransformingEmbeddedObjectSerializer<InputType, Transforme
             }
         } else if (jgen instanceof TokenBuffer) {
             TokenBuffer buffer = (TokenBuffer) jgen;
-            ObjectCodec codec = buffer.getCodec();
-            buffer.setCodec(null);
+            TokenStreamContext codec = buffer.streamWriteContext();
+            buffer.overrideParentContext(null);
             if (value == null && writeNullAsNull) {
                 buffer.writeNull();
             } else {
                 buffer.writePOJO(value);
             }
-            buffer.setCodec(codec);
+            buffer.overrideParentContext(codec);
         } else {
             String message = "JsonGenerator of type "
-                + jgen.getClass().getName()
-                + " not supported: " + getClass().getName()
-                + " is designed for use only with "
-                + DBEncoderBsonGenerator.class.getName()
-                + " or "
-                + TokenBuffer.class.getName();
+                    + jgen.getClass().getName()
+                    + " not supported: " + getClass().getName()
+                    + " is designed for use only with "
+                    + DBEncoderBsonGenerator.class.getName()
+                    + " or "
+                    + TokenBuffer.class.getName();
             throw new IllegalArgumentException(message);
         }
     }
 
     /**
-     * Transform to the desired type.  Careful of nulls!
+     * Transform to the desired type. Careful of nulls!
      * 
      * @param value
      * @return

--- a/src/main/java/org/mongojack/TransformingEmbeddedObjectSerializer.java
+++ b/src/main/java/org/mongojack/TransformingEmbeddedObjectSerializer.java
@@ -16,14 +16,14 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.util.TokenBuffer;
 import org.mongojack.internal.stream.DBEncoderBsonGenerator;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.util.TokenBuffer;
 
 /**
  * Safe embedded object serializer.
@@ -31,20 +31,20 @@ import java.io.IOException;
  * When used with BsonObjectGenerator or DBEncoderBsonGenerator, passes values straight through.
  * <p>
  * When used with a {@link TokenBuffer} (as by {@link
- * com.fasterxml.jackson.databind.deser.BeanDeserializer#deserializeWithUnwrapped}),
+ * tools.jackson.databind.deser.BeanDeserializer#deserializeWithUnwrapped}),
  * temporarily clears the TokenBuffer codec before passing the value through,
  * so it will be properly serialized as an embedded object.
  * (Failure to do so would blow up the stack, as the TokenBuffer would
  * pass the object right back to the ObjectMapper.)
  * <p>
- * When used with other JsonSerializers, throws {@link IllegalArgumentException}
+ * When used with other ValueSerializers, throws {@link IllegalArgumentException}
  * with a message that it's designed for use only with BsonObjectGenerator or
  * DBEncoderBsonGenerator or TokenBuffer.
  *
  * @author Kevin D. Keck
  * @since 3.0.4
  */
-public abstract class TransformingEmbeddedObjectSerializer<InputType, TransformedType> extends JsonSerializer<InputType> {
+public abstract class TransformingEmbeddedObjectSerializer<InputType, TransformedType> extends ValueSerializer<InputType> {
 
     protected final boolean writeNullAsNull;
 
@@ -57,12 +57,12 @@ public abstract class TransformingEmbeddedObjectSerializer<InputType, Transforme
     }
 
     protected void writeEmbeddedObject(TransformedType value, JsonGenerator jgen)
-        throws IOException {
+            throws JacksonException {
         if (jgen instanceof DBEncoderBsonGenerator) {
             if (value == null && writeNullAsNull) {
                 jgen.writeNull();
             } else {
-                jgen.writeObject(value);
+                jgen.writePOJO(value);
             }
         } else if (jgen instanceof TokenBuffer) {
             TokenBuffer buffer = (TokenBuffer) jgen;
@@ -71,7 +71,7 @@ public abstract class TransformingEmbeddedObjectSerializer<InputType, Transforme
             if (value == null && writeNullAsNull) {
                 buffer.writeNull();
             } else {
-                buffer.writeObject(value);
+                buffer.writePOJO(value);
             }
             buffer.setCodec(codec);
         } else {
@@ -96,9 +96,8 @@ public abstract class TransformingEmbeddedObjectSerializer<InputType, Transforme
 
     @Override
     public void serialize(
-        InputType value, JsonGenerator jgen,
-        SerializerProvider provider
-    ) throws IOException {
+            InputType value, JsonGenerator jgen,
+            SerializationContext provider) throws JacksonException {
         writeEmbeddedObject(transform(value), jgen);
     }
 

--- a/src/main/java/org/mongojack/internal/AnnotationHelper.java
+++ b/src/main/java/org/mongojack/internal/AnnotationHelper.java
@@ -15,9 +15,11 @@
  */
 package org.mongojack.internal;
 
+import java.lang.annotation.Annotation;
+
 import org.mongojack.Id;
 
-import com.fasterxml.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.Annotated;
 
 /**
  * Helper to deal with annotations.
@@ -26,9 +28,9 @@ import com.fasterxml.jackson.databind.introspect.Annotated;
  */
 public class AnnotationHelper {
 
-    private static final Class<?> JAVAX_PERSIST_ID_CLASS = initPersistIdClass("javax.persistence.Id");
-    private static final Class<?> JAKARTA_PERSIST_ID_CLASS = initPersistIdClass("jakarta.persistence.Id");
-    private static final Class<?> BSON_PERSIST_ID_CLASS = initPersistIdClass("org.bson.codecs.pojo.annotations.BsonId");
+    private static final Class<? extends Annotation> JAVAX_PERSIST_ID_CLASS = initPersistIdClass("javax.persistence.Id");
+    private static final Class<? extends Annotation> JAKARTA_PERSIST_ID_CLASS = initPersistIdClass("jakarta.persistence.Id");
+    private static final Class<? extends Annotation> BSON_PERSIST_ID_CLASS = initPersistIdClass("org.bson.codecs.pojo.annotations.BsonId");
 
     private AnnotationHelper() {
         super();
@@ -36,14 +38,14 @@ public class AnnotationHelper {
 
     public static boolean hasIdAnnotation(Annotated annotated) {
         return annotated.hasAnnotation(Id.class) ||
-            (JAVAX_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAVAX_PERSIST_ID_CLASS)) ||
-            (JAKARTA_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAKARTA_PERSIST_ID_CLASS))||
-            (BSON_PERSIST_ID_CLASS != null && annotated.hasAnnotation(BSON_PERSIST_ID_CLASS));
+                (JAVAX_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAVAX_PERSIST_ID_CLASS)) ||
+                (JAKARTA_PERSIST_ID_CLASS != null && annotated.hasAnnotation(JAKARTA_PERSIST_ID_CLASS)) ||
+                (BSON_PERSIST_ID_CLASS != null && annotated.hasAnnotation(BSON_PERSIST_ID_CLASS));
     }
 
-    private static Class<?> initPersistIdClass(String className) {
+    private static Class<? extends Annotation> initPersistIdClass(String className) {
         try {
-            return Class.forName(className);
+            return (Class<? extends Annotation>) Class.forName(className);
         } catch (ClassNotFoundException e) {
             return null; // javax or jakarta persist @Id will not be supported
         }

--- a/src/main/java/org/mongojack/internal/BsonMapSerializer.java
+++ b/src/main/java/org/mongojack/internal/BsonMapSerializer.java
@@ -1,17 +1,17 @@
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 import java.util.Map;
 
 public class BsonMapSerializer {
 
-    public void serializeSimpleBsonMap(Map<String, ?> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serializeSimpleBsonMap(Map<String, ?> value, JsonGenerator gen, SerializationContext serializers) throws JacksonException {
         gen.writeStartObject();
         for (Map.Entry<String, ?> entry : value.entrySet()) {
-            gen.writeFieldName(entry.getKey());
+            gen.writeName(entry.getKey());
             Object entryValue = entry.getValue();
             if (entryValue == null) {
                 gen.writeNull();

--- a/src/main/java/org/mongojack/internal/BsonSerializer.java
+++ b/src/main/java/org/mongojack/internal/BsonSerializer.java
@@ -1,21 +1,21 @@
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.SerializationContext;
 import org.bson.BasicBSONObject;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
-public class BsonSerializer extends JsonSerializer<Bson> {
+public class BsonSerializer extends ValueSerializer<Bson> {
 
     private final BsonMapSerializer bsonMapSerializer = new BsonMapSerializer();
 
     @Override
-    public void serialize(Bson value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(Bson value, JsonGenerator gen, SerializationContext serializers) throws JacksonException {
         if (value == null) {
             gen.writeNull();
         } else if (value instanceof BsonDocument) {

--- a/src/main/java/org/mongojack/internal/BsonValueSerializer.java
+++ b/src/main/java/org/mongojack/internal/BsonValueSerializer.java
@@ -1,29 +1,29 @@
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.SerializationContext;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonNull;
 import org.bson.BsonValue;
 import org.mongojack.internal.stream.JsonGeneratorAdapter;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
-public class BsonValueSerializer extends JsonSerializer<BsonValue> {
+public class BsonValueSerializer extends ValueSerializer<BsonValue> {
 
     private final BsonMapSerializer bsonMapSerializer = new BsonMapSerializer();
 
     @Override
-    public void serialize(BsonValue value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(BsonValue value, JsonGenerator gen, SerializationContext serializers) throws JacksonException {
         if (value == null || value instanceof BsonNull) {
             gen.writeNull();
         } else if (value instanceof BsonDocument) {
             bsonMapSerializer.serializeSimpleBsonMap((BsonDocument) value, gen, serializers);
         } else if (value instanceof BsonArray) {
             gen.writeStartArray();
-            JsonSerializer<Object> ser = serializers.findValueSerializer(BsonValue.class);
+            ValueSerializer<Object> ser = serializers.findValueSerializer(BsonValue.class);
             for (BsonValue bsonValue : ((BsonArray) value).getValues()) {
                 ser.serialize(bsonValue, gen, serializers);
             }

--- a/src/main/java/org/mongojack/internal/CalendarDeserializer.java
+++ b/src/main/java/org/mongojack/internal/CalendarDeserializer.java
@@ -16,12 +16,12 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -38,8 +38,8 @@ public class CalendarDeserializer extends StdDeserializer<Calendar> {
 
     @Override
     public Calendar deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException {
-        JsonToken token = jp.getCurrentToken();
+            throws JacksonException {
+        JsonToken token = jp.currentToken();
         Date date;
         if (token == JsonToken.VALUE_EMBEDDED_OBJECT) {
             // See if it's a date

--- a/src/main/java/org/mongojack/internal/DBRefDeserializer.java
+++ b/src/main/java/org/mongojack/internal/DBRefDeserializer.java
@@ -16,15 +16,15 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ValueDeserializer;
 import org.mongojack.DBRef;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
 /**
  * Deserializer for DBRefs
@@ -32,18 +32,18 @@ import java.io.IOException;
  * @author James Roper
  * @since 1.2
  */
-public class DBRefDeserializer<T, K> extends JsonDeserializer<DBRef> {
+public class DBRefDeserializer<T, K> extends ValueDeserializer<DBRef> {
 
     private final JavaType type;
     private final JavaType keyType;
-    private final JsonDeserializer<K> keyDeserializer;
+    private final ValueDeserializer<K> keyDeserializer;
 
     public DBRefDeserializer(JavaType type, JavaType keyType) {
         this(type, keyType, null);
     }
 
     public DBRefDeserializer(JavaType type, JavaType keyType,
-            JsonDeserializer<K> keyDeserializer) {
+            ValueDeserializer<K> keyDeserializer) {
         this.type = type;
         this.keyType = keyType;
         this.keyDeserializer = keyDeserializer;
@@ -51,11 +51,11 @@ public class DBRefDeserializer<T, K> extends JsonDeserializer<DBRef> {
 
     @Override
     public DBRef deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException, JsonProcessingException {
+            throws JacksonException, JacksonException {
         K id = null;
         String collectionName = null;
         String databaseName = null;
-        JsonToken token = jp.getCurrentToken();
+        JsonToken token = jp.currentToken();
         if (token == JsonToken.VALUE_NULL) {
             return null;
         }
@@ -78,15 +78,15 @@ public class DBRefDeserializer<T, K> extends JsonDeserializer<DBRef> {
         } else if (token == JsonToken.START_OBJECT) {
             token = jp.nextValue();
             while (token != JsonToken.END_OBJECT) {
-                if (jp.getCurrentName().equals("$id")) {
+                if (jp.currentName().equals("$id")) {
                     if (keyDeserializer != null) {
                         id = keyDeserializer.deserialize(jp, ctxt);
                     } else {
                         id = (K) jp.getEmbeddedObject();
                     }
-                } else if (jp.getCurrentName().equals("$ref")) {
+                } else if (jp.currentName().equals("$ref")) {
                     collectionName = jp.getText();
-                } else if (jp.getCurrentName().equals("$db")) {
+                } else if (jp.currentName().equals("$db")) {
                     databaseName = jp.getText();
                 } else {
                     // Ignore the rest

--- a/src/main/java/org/mongojack/internal/DBRefSerializer.java
+++ b/src/main/java/org/mongojack/internal/DBRefSerializer.java
@@ -16,12 +16,12 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.SerializationContext;
 import org.mongojack.DBRef;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
 /**
  * Serialises DBRef objects
@@ -30,21 +30,21 @@ import java.io.IOException;
  * @since 1.2
  */
 @SuppressWarnings("rawtypes")
-public class DBRefSerializer extends JsonSerializer<DBRef> {
+public class DBRefSerializer extends ValueSerializer<DBRef> {
 
     @Override
-    public void serialize(final DBRef value, final JsonGenerator gen, final SerializerProvider serializers) throws IOException {
+    public void serialize(final DBRef value, final JsonGenerator gen, final SerializationContext serializers) throws JacksonException {
         if (value == null) {
             gen.writeNull();
         } else {
             gen.writeStartObject();
-            gen.writeFieldName("$ref");
+            gen.writeName("$ref");
             gen.writeString(value.getCollectionName());
-            gen.writeFieldName("$id");
-            gen.writeObject(value.getId());
+            gen.writeName("$id");
+            gen.writePOJO(value.getId());
             if (value.getDatabaseName() != null) {
-                gen.writeFieldName("$db");
-                gen.writeObject(value.getDatabaseName());
+                gen.writeName("$db");
+                gen.writePOJO(value.getDatabaseName());
             }
             gen.writeEndObject();
         }

--- a/src/main/java/org/mongojack/internal/DateDeserializer.java
+++ b/src/main/java/org/mongojack/internal/DateDeserializer.java
@@ -16,12 +16,12 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 import java.util.Date;
 
 /**
@@ -39,8 +39,8 @@ public class DateDeserializer extends StdDeserializer<Date> {
 
     @Override
     public Date deserialize(JsonParser jp, DeserializationContext ctxt)
-        throws IOException {
-        JsonToken token = jp.getCurrentToken();
+        throws JacksonException {
+        JsonToken token = jp.currentToken();
         if (token == JsonToken.VALUE_EMBEDDED_OBJECT) {
             // See if it's a date
             Object date = jp.getEmbeddedObject();

--- a/src/main/java/org/mongojack/internal/EmbeddedObjectSerializer.java
+++ b/src/main/java/org/mongojack/internal/EmbeddedObjectSerializer.java
@@ -16,14 +16,14 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.util.TokenBuffer;
 import org.mongojack.TransformingEmbeddedObjectSerializer;
 import org.mongojack.internal.stream.DBEncoderBsonGenerator;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.util.TokenBuffer;
 
 /**
  * Safe embedded object serializer.
@@ -31,13 +31,13 @@ import java.io.IOException;
  * When used with BsonObjectGenerator or DBEncoderBsonGenerator, passes values straight through.
  * <p>
  * When used with a {@link TokenBuffer} (as by {@link
- * com.fasterxml.jackson.databind.deser.BeanDeserializer#deserializeWithUnwrapped}),
+ * tools.jackson.databind.deser.BeanDeserializer#deserializeWithUnwrapped}),
  * temporarily clears the TokenBuffer codec before passing the value through,
  * so it will be properly serialized as an embedded object.
  * (Failure to do so would blow up the stack, as the TokenBuffer would
  * pass the object right back to the ObjectMapper.)
  * <p>
- * When used with other JsonSerializers, throws {@link java.lang.IllegalArgumentException}
+ * When used with other ValueSerializers, throws {@link java.lang.IllegalArgumentException}
  * with a message that it's designed for use only with BsonObjectGenerator or
  * DBEncoderBsonGenerator or TokenBuffer.
  *
@@ -60,9 +60,9 @@ public abstract class EmbeddedObjectSerializer<T> extends TransformingEmbeddedOb
     }
 
     protected void writeEmbeddedObject(T value, JsonGenerator jgen)
-        throws IOException {
+            throws JacksonException {
         if (jgen instanceof DBEncoderBsonGenerator) {
-            jgen.writeObject(value);
+            jgen.writePOJO(value);
         } else if (jgen instanceof TokenBuffer) {
             TokenBuffer buffer = (TokenBuffer) jgen;
             ObjectCodec codec = buffer.getCodec();
@@ -83,9 +83,8 @@ public abstract class EmbeddedObjectSerializer<T> extends TransformingEmbeddedOb
 
     @Override
     public void serialize(
-        T value, JsonGenerator jgen,
-        SerializerProvider provider
-    ) throws IOException {
+            T value, JsonGenerator jgen,
+            SerializationContext provider) throws JacksonException {
         writeEmbeddedObject(value, jgen);
     }
 }

--- a/src/main/java/org/mongojack/internal/EmbeddedObjectSerializer.java
+++ b/src/main/java/org/mongojack/internal/EmbeddedObjectSerializer.java
@@ -65,18 +65,18 @@ public abstract class EmbeddedObjectSerializer<T> extends TransformingEmbeddedOb
             jgen.writePOJO(value);
         } else if (jgen instanceof TokenBuffer) {
             TokenBuffer buffer = (TokenBuffer) jgen;
-            ObjectCodec codec = buffer.getCodec();
-            buffer.setCodec(null);
-            buffer.writeObject(value);
-            buffer.setCodec(codec);
+            TokenStreamContext ctx = buffer.streamWriteContext();
+            buffer.overrideParentContext(null);
+            buffer.writePOJO(value);
+            buffer.overrideParentContext(ctx);
         } else {
             String message = "JsonGenerator of type "
-                + jgen.getClass().getName()
-                + " not supported: " + getClass().getName()
-                + " is designed for use only with "
-                + DBEncoderBsonGenerator.class.getName()
-                + " or "
-                + TokenBuffer.class.getName();
+                    + jgen.getClass().getName()
+                    + " not supported: " + getClass().getName()
+                    + " is designed for use only with "
+                    + DBEncoderBsonGenerator.class.getName()
+                    + " or "
+                    + TokenBuffer.class.getName();
             throw new IllegalArgumentException(message);
         }
     }

--- a/src/main/java/org/mongojack/internal/EmbeddedObjectSerializer.java
+++ b/src/main/java/org/mongojack/internal/EmbeddedObjectSerializer.java
@@ -21,7 +21,6 @@ import org.mongojack.internal.stream.DBEncoderBsonGenerator;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
-import tools.jackson.core.TokenStreamContext;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.util.TokenBuffer;
 
@@ -65,10 +64,7 @@ public abstract class EmbeddedObjectSerializer<T> extends TransformingEmbeddedOb
             jgen.writePOJO(value);
         } else if (jgen instanceof TokenBuffer) {
             TokenBuffer buffer = (TokenBuffer) jgen;
-            TokenStreamContext ctx = buffer.streamWriteContext();
-            buffer.overrideParentContext(null);
-            buffer.writePOJO(value);
-            buffer.overrideParentContext(ctx);
+            buffer.writeEmbeddedObject(value);
         } else {
             String message = "JsonGenerator of type "
                     + jgen.getClass().getName()

--- a/src/main/java/org/mongojack/internal/MongoAnnotationIntrospector.java
+++ b/src/main/java/org/mongojack/internal/MongoAnnotationIntrospector.java
@@ -16,18 +16,19 @@
  */
 package org.mongojack.internal;
 
+import java.lang.reflect.Type;
+
 import org.mongojack.DBRef;
 import org.mongojack.ObjectId;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
-import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.fasterxml.jackson.databind.PropertyName;
-
-import java.lang.reflect.Type;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.PropertyName;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.AnnotatedMethod;
+import tools.jackson.databind.introspect.NopAnnotationIntrospector;
+import tools.jackson.databind.type.TypeFactory;
 
 /**
  * Annotation introspector that supports @ObjectId's
@@ -44,7 +45,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
 
     // Handling of javax.persistence.Id and jakarta.persistence.Id
     @Override
-    public PropertyName findNameForDeserialization(Annotated a) {
+    public PropertyName findNameForDeserialization(MapperConfig<?> cfg, Annotated a) {
 
         String rawName = findPropertyName(a);
         if (rawName != null) {
@@ -54,7 +55,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     @Override
-    public PropertyName findNameForSerialization(Annotated a) {
+    public PropertyName findNameForSerialization(MapperConfig<?> cfg, Annotated a) {
 
         String rawName = findPropertyName(a);
         if (rawName != null) {
@@ -79,7 +80,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
 
     // Handling of ObjectId annotated properties
     @Override
-    public Object findSerializer(Annotated am) {
+    public Object findSerializer(MapperConfig<?> cfg, Annotated am) {
         if (am.hasAnnotation(ObjectId.class)) {
             return ObjectIdSerializer.class;
         }
@@ -87,7 +88,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     @Override
-    public Object findDeserializer(Annotated am) {
+    public Object findDeserializer(MapperConfig<?> cfg, Annotated am) {
         if (am.hasAnnotation(ObjectId.class)) {
             return findObjectIdDeserializer(typeFactory.constructType(getTypeForAnnotated(am)));
         }
@@ -95,7 +96,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
     }
 
     @Override
-    public JsonDeserializer findContentDeserializer(Annotated am) {
+    public ValueDeserializer findContentDeserializer(MapperConfig<?> cfg, Annotated am) {
         if (am.hasAnnotation(ObjectId.class)) {
             JavaType type = typeFactory.constructType(getTypeForAnnotated(am));
             if (type.isCollectionLikeType()) {
@@ -107,7 +108,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
         return null;
     }
 
-    public JsonDeserializer findObjectIdDeserializer(JavaType type) {
+    public ValueDeserializer findObjectIdDeserializer(JavaType type) {
         if (type.getRawClass() == String.class) {
             return new ObjectIdDeserializers.ToStringDeserializer();
         } else if (type.getRawClass() == byte[].class) {
@@ -125,7 +126,7 @@ public class MongoAnnotationIntrospector extends NopAnnotationIntrospector {
             } else {
                 dbRefType = type;
             }
-            JsonDeserializer keyDeserializer = findObjectIdDeserializer(dbRefType
+            ValueDeserializer keyDeserializer = findObjectIdDeserializer(dbRefType
                     .containedType(1));
             return new DBRefDeserializer(dbRefType.containedType(0),
                     dbRefType.containedType(1), keyDeserializer);

--- a/src/main/java/org/mongojack/internal/MongoDBRefDeserializer.java
+++ b/src/main/java/org/mongojack/internal/MongoDBRefDeserializer.java
@@ -16,13 +16,13 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 import com.mongodb.DBRef;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
 
 /**
@@ -31,28 +31,28 @@ import java.io.IOException;
  * @author James Roper
  * @since 1.2
  */
-public class MongoDBRefDeserializer extends JsonDeserializer<DBRef> {
+public class MongoDBRefDeserializer extends ValueDeserializer<DBRef> {
 
     @Override
-    public DBRef deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-        if (jp.getCurrentToken() == JsonToken.VALUE_NULL) {
+    public DBRef deserialize(JsonParser jp, DeserializationContext ctxt) throws JacksonException {
+        if (jp.currentToken() == JsonToken.VALUE_NULL) {
             return null;
         }
-        if (jp.getCurrentToken() == JsonToken.VALUE_EMBEDDED_OBJECT) {
+        if (jp.currentToken() == JsonToken.VALUE_EMBEDDED_OBJECT) {
             Object object = jp.getEmbeddedObject();
             if (object instanceof  DBRef) {
                 return (DBRef)object;
             } else {
                 throw ctxt.instantiationException(DBRef.class, "Don't know what to do with embedded object: " + object);
             }
-        } else if (jp.getCurrentToken() == JsonToken.START_OBJECT) {
+        } else if (jp.currentToken() == JsonToken.START_OBJECT) {
             Object id = null;
             String collectionName = null;
             String databaseName = null;
             while (jp.nextValue() != JsonToken.END_OBJECT) {
-                switch (jp.getCurrentName()) {
+                switch (jp.currentName()) {
                     case "$id":
-                        switch (jp.getCurrentToken()) {
+                        switch (jp.currentToken()) {
                             case VALUE_EMBEDDED_OBJECT:
                                 id = jp.getEmbeddedObject();
                                 break;

--- a/src/main/java/org/mongojack/internal/MongoDBRefSerializer.java
+++ b/src/main/java/org/mongojack/internal/MongoDBRefSerializer.java
@@ -16,12 +16,12 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.SerializationContext;
 import com.mongodb.DBRef;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
 /**
  * Serialises DBRef objects
@@ -29,21 +29,21 @@ import java.io.IOException;
  * @author James Roper
  * @since 1.2
  */
-public class MongoDBRefSerializer extends JsonSerializer<DBRef> {
+public class MongoDBRefSerializer extends ValueSerializer<DBRef> {
 
     @Override
-    public void serialize(final DBRef value, final JsonGenerator gen, final SerializerProvider serializers) throws IOException {
+    public void serialize(final DBRef value, final JsonGenerator gen, final SerializationContext serializers) throws JacksonException {
         if (value == null) {
             gen.writeNull();
         } else {
             gen.writeStartObject();
-            gen.writeFieldName("$ref");
+            gen.writeName("$ref");
             gen.writeString(value.getCollectionName());
-            gen.writeFieldName("$id");
-            gen.writeObject(value.getId());
+            gen.writeName("$id");
+            gen.writePOJO(value.getId());
             if (value.getDatabaseName() != null) {
-                gen.writeFieldName("$db");
-                gen.writeObject(value.getDatabaseName());
+                gen.writeName("$db");
+                gen.writePOJO(value.getDatabaseName());
             }
             gen.writeEndObject();
         }

--- a/src/main/java/org/mongojack/internal/MongoJackDeserializers.java
+++ b/src/main/java/org/mongojack/internal/MongoJackDeserializers.java
@@ -16,21 +16,27 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.module.SimpleDeserializers;
-import org.bson.Document;
-import org.bson.conversions.Bson;
-import org.mongojack.DBRef;
-import org.mongojack.MongoJackModuleConfiguration;
-import org.mongojack.MongoJackModuleFeature;
-
-import java.io.IOException;
 import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.mongojack.DBRef;
+import org.mongojack.MongoDatabindException;
+import org.mongojack.MongoJackModuleConfiguration;
+import org.mongojack.MongoJackModuleFeature;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationConfig;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.module.SimpleDeserializers;
 
 /**
  * Deserializers for MongoJack
@@ -50,10 +56,10 @@ public class MongoJackDeserializers extends SimpleDeserializers {
         addDeserializer(UUID.class, new UUIDDeserializer());
         addDeserializer(com.mongodb.DBRef.class, new MongoDBRefDeserializer());
         if (config.isEnabled(MongoJackModuleFeature.ENABLE_BSON_VALUE_SERIALIZATION)) {
-            addDeserializer(Bson.class, new JsonDeserializer<Bson>() {
+            addDeserializer(Bson.class, new ValueDeserializer<Bson>() {
                 @Override
-                public Bson deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-                    JsonDeserializer<Object> nonContextualValueDeserializer = ctxt.findRootValueDeserializer(ctxt.constructType(Document.class));
+                public Bson deserialize(JsonParser jp, DeserializationContext ctxt) throws JacksonException {
+                    ValueDeserializer<Object> nonContextualValueDeserializer = ctxt.findRootValueDeserializer(ctxt.constructType(Document.class));
                     return (Document) nonContextualValueDeserializer.deserialize(jp, ctxt);
                 }
             });
@@ -61,17 +67,17 @@ public class MongoJackDeserializers extends SimpleDeserializers {
     }
 
     @Override
-    public JsonDeserializer<?> findBeanDeserializer(JavaType type,
-                                                    DeserializationConfig config, BeanDescription beanDesc)
-        throws JsonMappingException {
+    public ValueDeserializer<?> findBeanDeserializer(JavaType type,
+            DeserializationConfig config, BeanDescription.Supplier beanDescSupplier)
+            throws DatabindException {
         if (type.getRawClass() == DBRef.class) {
             if (type.containedTypeCount() != 2) {
-                throw new JsonMappingException(null, "Property doesn't declare object and key type");
+                throw new MongoDatabindException("Property doesn't declare object and key type");
             }
             JavaType objectType = type.containedType(0);
             JavaType keyType = type.containedType(1);
             return new DBRefDeserializer(objectType, keyType);
         }
-        return super.findBeanDeserializer(type, config, beanDesc);
+        return super.findBeanDeserializer(type, config, beanDescSupplier);
     }
 }

--- a/src/main/java/org/mongojack/internal/MongoJackInstantDeserializer.java
+++ b/src/main/java/org/mongojack/internal/MongoJackInstantDeserializer.java
@@ -1,14 +1,15 @@
 package org.mongojack.internal;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonTokenId;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonTokenId;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.ext.javatime.deser.InstantDeserializer;
 
 /**
  * Patched {@link java.time.Instant} deserializer. Works with bson4jackson-deserialized ISODate() fields
@@ -16,18 +17,24 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
  * @author Mikhail Surin
  */
 public class MongoJackInstantDeserializer extends InstantDeserializer<Instant> {
+    private final static boolean DEFAULT_NORMALIZE_ZONE_ID = DateTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
+    private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS = DateTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
+            .enabledByDefault();
+
     public MongoJackInstantDeserializer() {
         super(Instant.class, DateTimeFormatter.ISO_INSTANT,
                 Instant::from,
                 a -> Instant.ofEpochMilli(a.value),
                 a -> Instant.ofEpochSecond(a.integer, a.fraction),
                 null,
-                true);
+                true, // yes, replace zero offset with Z
+                DEFAULT_NORMALIZE_ZONE_ID,
+                DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS);
     }
 
     @Override
-    public Instant deserialize(JsonParser parser, DeserializationContext context) throws IOException {
-        if (parser.getCurrentTokenId() == JsonTokenId.ID_EMBEDDED_OBJECT) {
+    public Instant deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
+        if (parser.currentTokenId() == JsonTokenId.ID_EMBEDDED_OBJECT) {
             Object embeddedObject = parser.getEmbeddedObject();
             if (embeddedObject instanceof Instant) {
                 return (Instant) embeddedObject;

--- a/src/main/java/org/mongojack/internal/MongoJackInstantSerializer.java
+++ b/src/main/java/org/mongojack/internal/MongoJackInstantSerializer.java
@@ -1,14 +1,16 @@
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
-import org.mongojack.TransformingEmbeddedObjectSerializer;
-
-import java.io.IOException;
 import java.time.Instant;
 import java.util.Date;
+
+import org.mongojack.TransformingEmbeddedObjectSerializer;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.ext.javatime.ser.InstantSerializer;
 
 /**
  * Serialises {@link Instant}s as BSON dates when nanosecond precision is disabled.
@@ -30,8 +32,8 @@ public class MongoJackInstantSerializer extends TransformingEmbeddedObjectSerial
     }
 
     @Override
-    public void serialize(Instant value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        if (provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+    public void serialize(Instant value, JsonGenerator jgen, SerializationContext provider) throws JacksonException {
+        if (provider.isEnabled(DateTimeFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
             defaultSerializer.serialize(value, jgen, provider);
         } else {
             super.serialize(value, jgen, provider);

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -83,6 +83,12 @@ public class MongoJackModule extends JacksonModule {
             builder.addModule(new MongoJackModule(moduleConfiguration));
         }
 
+        // JacksonCodec.decode is called multiple times on the same stream in order to deserialize multiple objects out
+        // of an array.
+        // This means that the stream will have trailing tokens after the first object is deserialized, and we don't
+        // want to fail on that.
+        builder.disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
         // to allow setters like set_id() which have leading underscore, and are common when using MongoDB
         builder.accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true));
 

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -16,14 +16,17 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.mongojack.MongoJackModuleConfiguration;
 import org.mongojack.MongoJackModuleFeature;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import tools.jackson.core.Version;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy;
 
 /**
  * The ObjectID serialising module
@@ -31,13 +34,11 @@ import org.mongojack.MongoJackModuleFeature;
  * @author James Roper
  * @since 1.0
  */
-public class MongoJackModule extends Module {
+public class MongoJackModule extends JacksonModule {
 
     public static final MongoJackModuleConfiguration DEFAULT_CONFIGURATION = new MongoJackModuleConfiguration();
 
-    public static final Module DEFAULT_MODULE_INSTANCE = new MongoJackModule();
-
-    public static final Module DEFAULT_JAVA_TIME_MODULE = new JavaTimeModule();
+    public static final JacksonModule DEFAULT_MODULE_INSTANCE = new MongoJackModule();
 
     private final MongoJackModuleConfiguration moduleConfiguration;
 
@@ -75,11 +76,6 @@ public class MongoJackModule extends Module {
      * @return This object mapper (for chaining)
      */
     public static ObjectMapper configure(ObjectMapper objectMapper, MongoJackModuleConfiguration moduleConfiguration) {
-        // register java time module
-        if (moduleConfiguration.isEnabled(MongoJackModuleFeature.REGISTER_JAVA_TIME)) {
-            objectMapper.registerModule(DEFAULT_JAVA_TIME_MODULE);
-        }
-
         if (moduleConfiguration == DEFAULT_CONFIGURATION) {
             objectMapper.registerModule(DEFAULT_MODULE_INSTANCE);
         } else {
@@ -109,7 +105,7 @@ public class MongoJackModule extends Module {
 
     @Override
     public void setupModule(SetupContext context) {
-        MongoAnnotationIntrospector annotationIntrospector = new MongoAnnotationIntrospector(context.getTypeFactory());
+        MongoAnnotationIntrospector annotationIntrospector = new MongoAnnotationIntrospector(context.typeFactory());
         context.insertAnnotationIntrospector(annotationIntrospector);
         // Only include non null properties, this makes it possible to use
         // object templates for querying and

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -76,21 +76,24 @@ public class MongoJackModule extends JacksonModule {
      * @return This object mapper (for chaining)
      */
     public static ObjectMapper configure(ObjectMapper objectMapper, MongoJackModuleConfiguration moduleConfiguration) {
+        var builder = objectMapper.rebuild();
         if (moduleConfiguration == DEFAULT_CONFIGURATION) {
-            objectMapper.registerModule(DEFAULT_MODULE_INSTANCE);
+            builder.addModule(DEFAULT_MODULE_INSTANCE);
         } else {
-            objectMapper.registerModule(new MongoJackModule(moduleConfiguration));
+            builder.addModule(new MongoJackModule(moduleConfiguration));
         }
 
         // disable serialize dates as timestamps because we have fewer runtime errors that way
         if (moduleConfiguration.isEnabled(MongoJackModuleFeature.DISABLE_DATES_AS_TIMESTAMPS)) {
-            objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+            builder.configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         }
 
         if (moduleConfiguration.isEnabled(MongoJackModuleFeature.SET_SERIALIZATION_INCLUSION_NON_NULL)) {
-            objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            builder
+                    .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+                    .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL));
         }
-        return objectMapper;
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/org/mongojack/internal/MongoJackModule.java
+++ b/src/main/java/org/mongojack/internal/MongoJackModule.java
@@ -83,6 +83,9 @@ public class MongoJackModule extends JacksonModule {
             builder.addModule(new MongoJackModule(moduleConfiguration));
         }
 
+        // to allow setters like set_id() which have leading underscore, and are common when using MongoDB
+        builder.accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true));
+
         // disable serialize dates as timestamps because we have fewer runtime errors that way
         if (moduleConfiguration.isEnabled(MongoJackModuleFeature.DISABLE_DATES_AS_TIMESTAMPS)) {
             builder.configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, false);

--- a/src/main/java/org/mongojack/internal/MongoJackSerializers.java
+++ b/src/main/java/org/mongojack/internal/MongoJackSerializers.java
@@ -16,7 +16,7 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.databind.module.SimpleSerializers;
+import tools.jackson.databind.module.SimpleSerializers;
 import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;

--- a/src/main/java/org/mongojack/internal/ObjectIdDeserializers.java
+++ b/src/main/java/org/mongojack/internal/ObjectIdDeserializers.java
@@ -16,14 +16,14 @@
  */
 package org.mongojack.internal;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
 import org.bson.types.ObjectId;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 import com.mongodb.DBRef;
 
 /**
@@ -34,10 +34,10 @@ import com.mongodb.DBRef;
  */
 public class ObjectIdDeserializers {
 
-    public static class ToStringDeserializer extends JsonDeserializer<String> {
+    public static class ToStringDeserializer extends ValueDeserializer<String> {
         @Override
         public String deserialize(JsonParser jp, DeserializationContext ctxt)
-                throws IOException, JsonProcessingException {
+                throws JacksonException, JacksonException {
             Object object = jp.getEmbeddedObject();
             if (object == null) {
                 return null;
@@ -60,10 +60,10 @@ public class ObjectIdDeserializers {
     }
 
     public static class ToByteArrayDeserializer extends
-            JsonDeserializer<byte[]> {
+            ValueDeserializer<byte[]> {
         @Override
         public byte[] deserialize(JsonParser jp, DeserializationContext ctxt)
-                throws IOException, JsonProcessingException {
+                throws JacksonException, JacksonException {
             Object object = jp.getEmbeddedObject();
             if (object == null) {
                 return null;
@@ -86,10 +86,10 @@ public class ObjectIdDeserializers {
     }
 
     public static class ToObjectIdDeserializer extends
-            JsonDeserializer<ObjectId> {
+            ValueDeserializer<ObjectId> {
         @Override
         public ObjectId deserialize(JsonParser jp, DeserializationContext ctxt)
-                throws IOException, JsonProcessingException {
+                throws JacksonException, JacksonException {
             Object object = jp.getEmbeddedObject();
             if (object == null) {
                 return null;

--- a/src/main/java/org/mongojack/internal/ObjectIdSerializer.java
+++ b/src/main/java/org/mongojack/internal/ObjectIdSerializer.java
@@ -16,14 +16,14 @@
  */
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.SerializationContext;
 import org.bson.types.ObjectId;
 import org.mongojack.DBRef;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
 /**
  * Serializer for object ids, serialises strings or byte arrays to an ObjectId
@@ -36,30 +36,30 @@ public class ObjectIdSerializer extends EmbeddedObjectSerializer {
     @Override
     public void serialize(
         Object value, JsonGenerator jgen,
-        SerializerProvider provider
-    ) throws IOException,
-        JsonProcessingException {
+        SerializationContext provider
+    ) throws JacksonException,
+        JacksonException {
         if (value instanceof Iterable) {
             jgen.writeStartArray();
             for (Object item : (Iterable) value) {
-                writeObject(serialiseObject(item, jgen), jgen);
+                writePOJO(serialiseObject(item, jgen), jgen);
             }
             jgen.writeEndArray();
         } else {
-            writeObject(serialiseObject(value, jgen), jgen);
+            writePOJO(serialiseObject(value, jgen), jgen);
         }
     }
 
-    private void writeObject(Object value, JsonGenerator jgen)
-        throws IOException, JsonMappingException {
+    private void writePOJO(Object value, JsonGenerator jgen)
+        throws JacksonException, DatabindException {
         if (value instanceof ObjectId) {
             writeEmbeddedObject(value, jgen);
         } else {
-            jgen.writeObject(value);
+            jgen.writePOJO(value);
         }
     }
 
-    private Object serialiseObject(Object value, JsonGenerator jgen) throws JsonMappingException {
+    private Object serialiseObject(Object value, JsonGenerator jgen) throws DatabindException {
         if (value == null) {
             return null;
         } else if (value instanceof String) {
@@ -76,7 +76,7 @@ public class ObjectIdSerializer extends EmbeddedObjectSerializer {
         } else if (value instanceof ObjectId) {
             return value;
         } else {
-            throw JsonMappingException.from(jgen, "Cannot deserialise object of type " + value.getClass() + " to ObjectId");
+            throw DatabindException.from(jgen, "Cannot deserialise object of type " + value.getClass() + " to ObjectId");
         }
     }
 }

--- a/src/main/java/org/mongojack/internal/UUIDDeserializer.java
+++ b/src/main/java/org/mongojack/internal/UUIDDeserializer.java
@@ -1,12 +1,12 @@
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 import org.bson.BsonBinary;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 import java.util.UUID;
 
 /**
@@ -16,12 +16,12 @@ import java.util.UUID;
  * @author Jared Tiala
  * @since 2.6.2
  */
-public class UUIDDeserializer extends JsonDeserializer<UUID> {
+public class UUIDDeserializer extends ValueDeserializer<UUID> {
 
     @Override
     public UUID deserialize(JsonParser jp, DeserializationContext ctxt)
-        throws IOException {
-        JsonToken token = jp.getCurrentToken();
+        throws JacksonException {
+        JsonToken token = jp.currentToken();
 
         if (token == JsonToken.VALUE_EMBEDDED_OBJECT) {
             Object object = jp.getEmbeddedObject();

--- a/src/main/java/org/mongojack/internal/UUIDSerializer.java
+++ b/src/main/java/org/mongojack/internal/UUIDSerializer.java
@@ -1,10 +1,10 @@
 package org.mongojack.internal;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.SerializationContext;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 import java.util.UUID;
 
 /**
@@ -14,11 +14,11 @@ import java.util.UUID;
  * @author Jared Tiala
  * @since 2.6.2
  */
-public class UUIDSerializer extends JsonSerializer<UUID> {
+public class UUIDSerializer extends ValueSerializer<UUID> {
 
     @Override
     public void serialize(UUID uuid, JsonGenerator jgen,
-            SerializerProvider provider) throws IOException {
-        jgen.writeObject(uuid);
+            SerializationContext provider) throws JacksonException {
+        jgen.writePOJO(uuid);
     }
 }

--- a/src/main/java/org/mongojack/internal/object/BsonObjectCursor.java
+++ b/src/main/java/org/mongojack/internal/object/BsonObjectCursor.java
@@ -26,8 +26,8 @@ import java.util.UUID;
 import org.bson.BSONObject;
 import org.bson.types.ObjectId;
 
-import com.fasterxml.jackson.core.JsonStreamContext;
-import com.fasterxml.jackson.core.JsonToken;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.JsonToken;
 import com.mongodb.DBRef;
 
 /**
@@ -36,7 +36,7 @@ import com.mongodb.DBRef;
  * @author James Roper
  * @since 1.0
  */
-abstract class BsonObjectCursor extends JsonStreamContext {
+abstract class BsonObjectCursor extends TokenStreamContext {
     /**
      * Parent cursor of this cursor, if any; null for root cursors.
      */
@@ -56,7 +56,7 @@ abstract class BsonObjectCursor extends JsonStreamContext {
     }
 
     @Override
-    public abstract String getCurrentName();
+    public abstract String currentName();
 
     public abstract JsonToken nextToken();
 
@@ -105,12 +105,12 @@ abstract class BsonObjectCursor extends JsonStreamContext {
         Object currentNode;
 
         public ArrayCursor(Iterable n, BsonObjectCursor p) {
-            super(JsonStreamContext.TYPE_ARRAY, p);
+            super(TokenStreamContext.TYPE_ARRAY, p);
             contents = n.iterator();
         }
 
         @Override
-        public String getCurrentName() {
+        public String currentName() {
             return null;
         }
 
@@ -146,14 +146,14 @@ abstract class BsonObjectCursor extends JsonStreamContext {
         boolean needField;
 
         public ObjectCursor(BSONObject object, BsonObjectCursor p) {
-            super(JsonStreamContext.TYPE_OBJECT, p);
+            super(TokenStreamContext.TYPE_OBJECT, p);
             this.object = object;
             fields = object.keySet().iterator();
             needField = true;
         }
 
         @Override
-        public String getCurrentName() {
+        public String currentName() {
             return currentFieldName;
         }
 
@@ -167,7 +167,7 @@ abstract class BsonObjectCursor extends JsonStreamContext {
                 }
                 needField = false;
                 currentFieldName = fields.next();
-                return JsonToken.FIELD_NAME;
+                return JsonToken.PROPERTY_NAME;
             }
             needField = true;
             return getToken(object.get(currentFieldName));

--- a/src/main/java/org/mongojack/internal/object/BsonObjectTraversingParser.java
+++ b/src/main/java/org/mongojack/internal/object/BsonObjectTraversingParser.java
@@ -392,4 +392,81 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
         return nodeCursor.currentNode();
     }
 
+    @Override
+    protected void _closeInput() throws IOException {
+    }
+
+    @Override
+    protected void _releaseBuffers() {
+    }
+
+    @Override
+    public Object streamReadInputSource() {
+        return null;
+    }
+
+    @Override
+    public Object currentValue() {
+        return nodeCursor.currentNode();
+    }
+
+    @Override
+    public void assignCurrentValue(Object v) {
+        nodeCursor.assignCurrentValue(v);
+
+    }
+
+    @Override
+    public boolean isNaN() {
+        if (!_closed) {
+            Object n = currentNode();
+            if (n instanceof Number) {
+                return Double.isNaN(((Number) n).doubleValue());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getString() {
+        if (_currToken == null) {
+            return null;
+        }
+        // need to separate handling a bit...
+        switch (_currToken) {
+            case PROPERTY_NAME:
+                return currentName();
+            case VALUE_STRING:
+                return (String) currentNode();
+            case VALUE_NUMBER_INT:
+            case VALUE_NUMBER_FLOAT:
+                return String.valueOf((Number) currentNode());
+            case VALUE_EMBEDDED_OBJECT:
+                return null;
+            default:
+                return _currToken.asString();
+        }
+    }
+
+    @Override
+    public char[] getStringCharacters() {
+        return getString().toCharArray();
+    }
+
+    @Override
+    public int getStringLength() {
+        return getString().length();
+    }
+
+    @Override
+    public int getStringOffset() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasStringCharacters() {
+        // generally we do not have efficient access as char[], hence:
+        return false;
+    }
+
 }

--- a/src/main/java/org/mongojack/internal/object/BsonObjectTraversingParser.java
+++ b/src/main/java/org/mongojack/internal/object/BsonObjectTraversingParser.java
@@ -16,26 +16,30 @@
  */
 package org.mongojack.internal.object;
 
-import com.fasterxml.jackson.core.Base64Variant;
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonStreamContext;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.core.base.ParserMinimalBase;
-import com.mongodb.BasicDBObject;
-import org.bson.BSONObject;
-import org.mongojack.internal.util.VersionUtils;
-
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import org.bson.BSONObject;
+import org.mongojack.internal.util.VersionUtils;
+
+import com.mongodb.BasicDBObject;
+
+import tools.jackson.core.Base64Variant;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.core.Version;
+import tools.jackson.core.base.ParserMinimalBase;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.io.IOContext;
+
 /**
  * Parses a BSONObject by traversing it. This class was copied from
- * {@link com.fasterxml.jackson.databind.node.TreeTraversingParser} and then
+ * {@link tools.jackson.databind.node.TreeTraversingParser} and then
  * adapted to be for BSONObject's, rather than JsonNode's.
  * <p>
  * While decoding by the cursor uses DBDecoderBsonParser, there are still things
@@ -96,7 +100,7 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
             nextToken();
             nextToken();
             nextToken();
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             // Ignore
         }
     }
@@ -138,7 +142,7 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
      */
 
     @Override
-    public void close() throws IOException {
+    public void close() throws JacksonException {
         if (!closed) {
             closed = true;
             nodeCursor = null;
@@ -153,7 +157,7 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
      */
 
     @Override
-    public JsonToken nextToken() throws IOException {
+    public JsonToken nextToken() throws JacksonException {
         if (nextToken != null) {
             _currToken = nextToken;
             nextToken = null;
@@ -165,13 +169,13 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
             // minor optimization: empty containers can be skipped
             if (!nodeCursor.currentHasChildren()) {
                 _currToken = (_currToken == JsonToken.START_OBJECT) ? JsonToken.END_OBJECT
-                    : JsonToken.END_ARRAY;
+                        : JsonToken.END_ARRAY;
                 return _currToken;
             }
             nodeCursor = nodeCursor.iterateChildren();
             _currToken = nodeCursor.nextToken();
             if (_currToken == JsonToken.START_OBJECT
-                || _currToken == JsonToken.START_ARRAY) {
+                    || _currToken == JsonToken.START_ARRAY) {
                 startContainer = true;
             }
             return _currToken;
@@ -185,7 +189,7 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
         _currToken = nodeCursor.nextToken();
         if (_currToken != null) {
             if (_currToken == JsonToken.START_OBJECT
-                || _currToken == JsonToken.START_ARRAY) {
+                    || _currToken == JsonToken.START_ARRAY) {
                 startContainer = true;
             }
             return _currToken;
@@ -197,7 +201,7 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public JsonParser skipChildren() throws IOException {
+    public JsonParser skipChildren() throws JacksonException {
         if (_currToken == JsonToken.START_OBJECT) {
             startContainer = false;
             _currToken = JsonToken.END_OBJECT;
@@ -220,23 +224,23 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
      */
 
     @Override
-    public String getCurrentName() {
-        return (nodeCursor == null) ? null : nodeCursor.getCurrentName();
+    public String currentName() {
+        return (nodeCursor == null) ? null : nodeCursor.currentName();
     }
 
     @Override
-    public JsonStreamContext getParsingContext() {
+    public TokenStreamContext streamReadContext() {
         return nodeCursor;
     }
 
     @Override
-    public JsonLocation getTokenLocation() {
-        return JsonLocation.NA;
+    public TokenStreamLocation currentTokenLocation() {
+        return TokenStreamLocation.NA;
     }
 
     @Override
-    public JsonLocation getCurrentLocation() {
-        return JsonLocation.NA;
+    public TokenStreamLocation currentLocation() {
+        return TokenStreamLocation.NA;
     }
 
     /*
@@ -252,8 +256,8 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
         }
         // need to separate handling a bit...
         switch (_currToken) {
-            case FIELD_NAME:
-                return nodeCursor.getCurrentName();
+            case PROPERTY_NAME:
+                return nodeCursor.currentName();
             case VALUE_STRING:
             case VALUE_NUMBER_INT:
             case VALUE_NUMBER_FLOAT:
@@ -265,24 +269,18 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public char[] getTextCharacters() throws IOException {
+    public char[] getTextCharacters() throws JacksonException {
         return getText().toCharArray();
     }
 
     @Override
-    public int getTextLength() throws IOException {
+    public int getTextLength() throws JacksonException {
         return getText().length();
     }
 
     @Override
-    public int getTextOffset() throws IOException {
+    public int getTextOffset() throws JacksonException {
         return 0;
-    }
-
-    @Override
-    public boolean hasTextCharacters() {
-        // generally we do not have efficient access as char[], hence:
-        return false;
     }
 
     /*
@@ -291,10 +289,10 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
      * /**********************************************************
      */
 
-    // public byte getByteValue() throws IOException
+    // public byte getByteValue() throws JacksonException
 
     @Override
-    public NumberType getNumberType() throws IOException {
+    public NumberType getNumberType() throws JacksonException {
         Object n = currentNode();
         if (n instanceof Integer) {
             return NumberType.INT;
@@ -309,12 +307,12 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
         } else if (n instanceof Long) {
             return NumberType.LONG;
         } else {
-            throw _constructError(n + " is not a number");
+            throw _constructReadException(n + " is not a number");
         }
     }
 
     @Override
-    public BigInteger getBigIntegerValue() throws IOException {
+    public BigInteger getBigIntegerValue() throws JacksonException {
         Number n = currentNumericNode();
         if (n instanceof BigInteger) {
             return (BigInteger) n;
@@ -324,7 +322,7 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public BigDecimal getDecimalValue() throws IOException {
+    public BigDecimal getDecimalValue() throws JacksonException {
         Number n = currentNumericNode();
         if (n instanceof BigDecimal) {
             return (BigDecimal) n;
@@ -334,37 +332,37 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public double getDoubleValue() throws IOException {
+    public double getDoubleValue() throws JacksonException {
         return currentNumericNode().doubleValue();
     }
 
     @Override
-    public float getFloatValue() throws IOException {
+    public float getFloatValue() throws JacksonException {
         return currentNumericNode().floatValue();
     }
 
     @Override
-    public long getLongValue() throws IOException {
+    public long getLongValue() throws JacksonException {
         return currentNumericNode().longValue();
     }
 
     @Override
-    public int getIntValue() throws IOException {
+    public int getIntValue() throws JacksonException {
 
         return currentNumericNode().intValue();
     }
 
     @Override
-    public Number getNumberValue() throws IOException {
+    public Number getNumberValue() throws JacksonException {
         return currentNumericNode();
     }
 
-    private Number currentNumericNode() throws JsonParseException {
+    private Number currentNumericNode() throws StreamReadException {
         Object n = currentNode();
         if (n instanceof Number) {
             return (Number) n;
         } else {
-            throw _constructError(n + " is not a number");
+            throw _constructReadException(n + " is not a number");
         }
     }
 
@@ -375,7 +373,7 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
      */
 
     @Override
-    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException {
+    public byte[] getBinaryValue(Base64Variant b64variant) throws JacksonException {
         Object n = currentNode();
         if (n instanceof byte[]) {
             return (byte[]) n;
@@ -386,18 +384,13 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public Object getEmbeddedObject() throws IOException {
+    public Object getEmbeddedObject() throws JacksonException {
         return currentNode();
     }
 
     @Override
-    protected void _handleEOF() throws JsonParseException {
+    protected void _handleEOF() throws StreamReadException {
         // There is no EOF?
-    }
-
-    @Override
-    public void overrideCurrentName(String name) {
-        // Hmm... do nothing?
     }
 
     /*

--- a/src/main/java/org/mongojack/internal/object/BsonObjectTraversingParser.java
+++ b/src/main/java/org/mongojack/internal/object/BsonObjectTraversingParser.java
@@ -56,8 +56,6 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
      * Configuration /**********************************************************
      */
 
-    protected ObjectCodec objectCodec;
-
     /**
      * Traversal context within tree
      */
@@ -92,10 +90,10 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
      * /**********************************************************
      */
     public BsonObjectTraversingParser(
-        Object rootValue,
-        ObjectCodec codec
-    ) {
-        this(new BasicDBObject("root", rootValue), null);
+            Object rootValue,
+            ObjectReadContext objectReadContext,
+            IOContext ioContext) {
+        this(new BasicDBObject("root", rootValue), objectReadContext, ioContext);
         try {
             nextToken();
             nextToken();
@@ -106,11 +104,10 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
     }
 
     private BsonObjectTraversingParser(
-        BSONObject o,
-        ObjectCodec codec
-    ) {
-        super(0);
-        objectCodec = codec;
+            BSONObject o,
+            ObjectReadContext objectReadContext,
+            IOContext ioContext) {
+        super(objectReadContext, ioContext, 0);
         if (o instanceof Iterable) {
             nextToken = JsonToken.START_ARRAY;
             nodeCursor = new BsonObjectCursor.ArrayCursor((Iterable) o, null);
@@ -123,16 +120,6 @@ public class BsonObjectTraversingParser extends ParserMinimalBase {
     @Override
     public Version version() {
         return VersionUtils.VERSION;
-    }
-
-    @Override
-    public void setCodec(ObjectCodec c) {
-        objectCodec = c;
-    }
-
-    @Override
-    public ObjectCodec getCodec() {
-        return objectCodec;
     }
 
     /*

--- a/src/main/java/org/mongojack/internal/object/document/DocumentObjectCursor.java
+++ b/src/main/java/org/mongojack/internal/object/document/DocumentObjectCursor.java
@@ -27,8 +27,8 @@ import org.bson.BSONObject;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 
-import com.fasterxml.jackson.core.JsonStreamContext;
-import com.fasterxml.jackson.core.JsonToken;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.JsonToken;
 import com.mongodb.DBRef;
 
 /**
@@ -37,7 +37,7 @@ import com.mongodb.DBRef;
  * @author James Roper
  * @since 1.0
  */
-abstract class DocumentObjectCursor extends JsonStreamContext {
+abstract class DocumentObjectCursor extends TokenStreamContext {
     /**
      * Parent cursor of this cursor, if any; null for root cursors.
      */
@@ -57,7 +57,7 @@ abstract class DocumentObjectCursor extends JsonStreamContext {
     }
 
     @Override
-    public abstract String getCurrentName();
+    public abstract String currentName();
 
     public abstract JsonToken nextToken();
 
@@ -106,12 +106,12 @@ abstract class DocumentObjectCursor extends JsonStreamContext {
         Object currentNode;
 
         public ArrayCursor(Iterable n, DocumentObjectCursor p) {
-            super(JsonStreamContext.TYPE_ARRAY, p);
+            super(TokenStreamContext.TYPE_ARRAY, p);
             contents = n.iterator();
         }
 
         @Override
-        public String getCurrentName() {
+        public String currentName() {
             return null;
         }
 
@@ -147,14 +147,14 @@ abstract class DocumentObjectCursor extends JsonStreamContext {
         boolean needField;
 
         public ObjectCursor(Document object, DocumentObjectCursor p) {
-            super(JsonStreamContext.TYPE_OBJECT, p);
+            super(TokenStreamContext.TYPE_OBJECT, p);
             this.object = object;
             fields = object.keySet().iterator();
             needField = true;
         }
 
         @Override
-        public String getCurrentName() {
+        public String currentName() {
             return currentFieldName;
         }
 
@@ -168,7 +168,7 @@ abstract class DocumentObjectCursor extends JsonStreamContext {
                 }
                 needField = false;
                 currentFieldName = fields.next();
-                return JsonToken.FIELD_NAME;
+                return JsonToken.PROPERTY_NAME;
             }
             needField = true;
             return getToken(object.get(currentFieldName));

--- a/src/main/java/org/mongojack/internal/object/document/DocumentObjectTraversingParser.java
+++ b/src/main/java/org/mongojack/internal/object/document/DocumentObjectTraversingParser.java
@@ -378,4 +378,73 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
         }
         return nodeCursor.currentNode();
     }
+
+    @Override
+    protected void _closeInput() throws IOException {
+    }
+
+    @Override
+    protected void _releaseBuffers() {
+    }
+
+    @Override
+    public Object streamReadInputSource() {
+        return null;
+    }
+
+    @Override
+    public Object currentValue() {
+        return nodeCursor.currentValue();
+    }
+
+    @Override
+    public void assignCurrentValue(Object v) {
+        nodeCursor.assignCurrentValue(v);
+    }
+
+    @Override
+    public boolean isNaN() {
+        return currentNode() instanceof Number n && Double.isNaN(n.doubleValue());
+    }
+
+    @Override
+    public String getString() throws JacksonException {
+        if (_currToken == null) {
+            return null;
+        }
+        // need to separate handling a bit...
+        switch (_currToken) {
+            case PROPERTY_NAME:
+                return currentName();
+            case VALUE_STRING:
+                return (String) currentNode();
+            case VALUE_NUMBER_INT:
+            case VALUE_NUMBER_FLOAT:
+                return String.valueOf((Number) currentNode());
+            case VALUE_EMBEDDED_OBJECT:
+                return null;
+            default:
+                return _currToken.asString();
+        }
+    }
+
+    @Override
+    public char[] getStringCharacters() throws JacksonException {
+        return getString().toCharArray();
+    }
+
+    @Override
+    public int getStringLength() throws JacksonException {
+        return getString().length();
+    }
+
+    @Override
+    public int getStringOffset() throws JacksonException {
+        return 0;
+    }
+
+    @Override
+    public boolean hasStringCharacters() {
+        return false;
+    }
 }

--- a/src/main/java/org/mongojack/internal/object/document/DocumentObjectTraversingParser.java
+++ b/src/main/java/org/mongojack/internal/object/document/DocumentObjectTraversingParser.java
@@ -23,19 +23,21 @@ import java.math.BigInteger;
 import org.bson.Document;
 import org.mongojack.internal.util.VersionUtils;
 
-import com.fasterxml.jackson.core.Base64Variant;
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonStreamContext;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.core.base.ParserMinimalBase;
+import tools.jackson.core.Base64Variant;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.core.Version;
+import tools.jackson.core.base.ParserMinimalBase;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.io.IOContext;
 
 /**
  * Parses a BSONObject by traversing it. This class was copied from
- * {@link com.fasterxml.jackson.databind.node.TreeTraversingParser} and then
+ * {@link tools.jackson.databind.node.TreeTraversingParser} and then
  * adapted to be for BSONObject's, rather than JsonNode's.
  * 
  * While decoding by the cursor uses DBDecoderBsonParser, there are still things
@@ -132,7 +134,7 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
      */
 
     @Override
-    public void close() throws IOException {
+    public void close() throws JacksonException {
         if (!closed) {
             closed = true;
             nodeCursor = null;
@@ -147,7 +149,7 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
      */
 
     @Override
-    public JsonToken nextToken() throws IOException {
+    public JsonToken nextToken() throws JacksonException {
         if (nextToken != null) {
             _currToken = nextToken;
             nextToken = null;
@@ -191,7 +193,7 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public JsonParser skipChildren() throws IOException {
+    public JsonParser skipChildren() throws JacksonException {
         if (_currToken == JsonToken.START_OBJECT) {
             startContainer = false;
             _currToken = JsonToken.END_OBJECT;
@@ -214,23 +216,23 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
      */
 
     @Override
-    public String getCurrentName() {
-        return (nodeCursor == null) ? null : nodeCursor.getCurrentName();
+    public String currentName() {
+        return (nodeCursor == null) ? null : nodeCursor.currentName();
     }
 
     @Override
-    public JsonStreamContext getParsingContext() {
+    public TokenStreamContext streamReadContext() {
         return nodeCursor;
     }
 
     @Override
-    public JsonLocation getTokenLocation() {
-        return JsonLocation.NA;
+    public TokenStreamLocation currentTokenLocation() {
+        return TokenStreamLocation.NA;
     }
 
     @Override
-    public JsonLocation getCurrentLocation() {
-        return JsonLocation.NA;
+    public TokenStreamLocation currentLocation() {
+        return TokenStreamLocation.NA;
     }
 
     /*
@@ -246,8 +248,8 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
         }
         // need to separate handling a bit...
         switch (_currToken) {
-            case FIELD_NAME:
-                return nodeCursor.getCurrentName();
+            case PROPERTY_NAME:
+                return nodeCursor.currentName();
             case VALUE_STRING:
             case VALUE_NUMBER_INT:
             case VALUE_NUMBER_FLOAT:
@@ -259,24 +261,18 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public char[] getTextCharacters() throws IOException {
+    public char[] getTextCharacters() throws JacksonException {
         return getText().toCharArray();
     }
 
     @Override
-    public int getTextLength() throws IOException {
+    public int getTextLength() throws JacksonException {
         return getText().length();
     }
 
     @Override
-    public int getTextOffset() throws IOException {
+    public int getTextOffset() throws JacksonException {
         return 0;
-    }
-
-    @Override
-    public boolean hasTextCharacters() {
-        // generally we do not have efficient access as char[], hence:
-        return false;
     }
 
     /*
@@ -285,10 +281,10 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
      * /**********************************************************
      */
 
-    // public byte getByteValue() throws IOException
+    // public byte getByteValue() throws JacksonException
 
     @Override
-    public NumberType getNumberType() throws IOException {
+    public NumberType getNumberType() throws JacksonException {
         Object n = currentNode();
         if (n instanceof Integer) {
             return NumberType.INT;
@@ -303,12 +299,12 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
         } else if (n instanceof Long) {
             return NumberType.LONG;
         } else {
-            throw _constructError(n + " is not a number");
+            throw _constructReadException(n + " is not a number");
         }
     }
 
     @Override
-    public BigInteger getBigIntegerValue() throws IOException {
+    public BigInteger getBigIntegerValue() throws JacksonException {
         Number n = currentNumericNode();
         if (n instanceof BigInteger) {
             return (BigInteger) n;
@@ -318,7 +314,7 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public BigDecimal getDecimalValue() throws IOException {
+    public BigDecimal getDecimalValue() throws JacksonException {
         Number n = currentNumericNode();
         if (n instanceof BigDecimal) {
             return (BigDecimal) n;
@@ -328,37 +324,37 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public double getDoubleValue() throws IOException {
+    public double getDoubleValue() throws JacksonException {
         return currentNumericNode().doubleValue();
     }
 
     @Override
-    public float getFloatValue() throws IOException {
+    public float getFloatValue() throws JacksonException {
         return currentNumericNode().floatValue();
     }
 
     @Override
-    public long getLongValue() throws IOException {
+    public long getLongValue() throws JacksonException {
         return currentNumericNode().longValue();
     }
 
     @Override
-    public int getIntValue() throws IOException {
+    public int getIntValue() throws JacksonException {
 
         return currentNumericNode().intValue();
     }
 
     @Override
-    public Number getNumberValue() throws IOException {
+    public Number getNumberValue() throws JacksonException {
         return currentNumericNode();
     }
 
-    private Number currentNumericNode() throws JsonParseException {
+    private Number currentNumericNode() throws StreamReadException {
         Object n = currentNode();
         if (n instanceof Number) {
             return (Number) n;
         } else {
-            throw _constructError(n + " is not a number");
+            throw _constructReadException(n + " is not a number");
         }
     }
 
@@ -369,7 +365,7 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
      */
 
     @Override
-    public byte[] getBinaryValue(Base64Variant b64variant) throws IOException {
+    public byte[] getBinaryValue(Base64Variant b64variant) throws JacksonException {
         Object n = currentNode();
         if (n instanceof byte[]) {
             return (byte[]) n;
@@ -380,18 +376,13 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
     }
 
     @Override
-    public Object getEmbeddedObject() throws IOException {
+    public Object getEmbeddedObject() throws JacksonException {
         return currentNode();
     }
 
     @Override
-    protected void _handleEOF() throws JsonParseException {
+    protected void _handleEOF() throws StreamReadException {
         // There is no EOF?
-    }
-
-    @Override
-    public void overrideCurrentName(String name) {
-        // Hmm... do nothing?
     }
 
     /*

--- a/src/main/java/org/mongojack/internal/object/document/DocumentObjectTraversingParser.java
+++ b/src/main/java/org/mongojack/internal/object/document/DocumentObjectTraversingParser.java
@@ -49,13 +49,6 @@ import tools.jackson.core.io.IOContext;
  */
 public class DocumentObjectTraversingParser extends ParserMinimalBase {
 
-    /*
-     * /********************************************************** /*
-     * Configuration /**********************************************************
-     */
-
-    protected ObjectCodec objectCodec;
-
     /**
      * Traversal context within tree
      */
@@ -89,20 +82,19 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
      * /********************************************************** /* Life-cycle
      * /**********************************************************
      */
-    public DocumentObjectTraversingParser(Object rootValue, ObjectCodec codec) {
-        this(new Document("root", rootValue), null);
+    public DocumentObjectTraversingParser(Object rootValue, ObjectReadContext readContext, IOContext ioContext) {
+        this(new Document("root", rootValue), null, null);
         try {
             nextToken();
             nextToken();
             nextToken();
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             // Ignore
         }
     }
 
-    public DocumentObjectTraversingParser(Document o, ObjectCodec codec) {
-        super(0);
-        objectCodec = codec;
+    public DocumentObjectTraversingParser(Document o, ObjectReadContext readContext, IOContext ioContext) {
+        super(readContext, ioContext, 0);
         if (o instanceof Iterable) {
             nextToken = JsonToken.START_ARRAY;
             nodeCursor = new DocumentObjectCursor.ArrayCursor((Iterable) o, null);
@@ -115,16 +107,6 @@ public class DocumentObjectTraversingParser extends ParserMinimalBase {
     @Override
     public Version version() {
         return VersionUtils.VERSION;
-    }
-
-    @Override
-    public void setCodec(ObjectCodec c) {
-        objectCodec = c;
-    }
-
-    @Override
-    public ObjectCodec getCodec() {
-        return objectCodec;
     }
 
     /*

--- a/src/main/java/org/mongojack/internal/stream/DBDecoderBsonParser.java
+++ b/src/main/java/org/mongojack/internal/stream/DBDecoderBsonParser.java
@@ -16,13 +16,14 @@
  */
 package org.mongojack.internal.stream;
 
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.io.IOContext;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bson.AbstractBsonReader;
 import org.bson.UuidRepresentation;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Parser that wraps BSONParser to convert bson4jackson ObjectIds to org.bson
@@ -46,8 +47,8 @@ public class DBDecoderBsonParser extends JsonParserAdapter {
     }
 
     @Override
-    public String getText() throws IOException {
-        if (JsonToken.VALUE_EMBEDDED_OBJECT == getCurrentToken()) {
+    public String getText() throws JacksonException {
+        if (JsonToken.VALUE_EMBEDDED_OBJECT == currentToken()) {
             return null;
         }
         return super.getText();

--- a/src/main/java/org/mongojack/internal/stream/DBDecoderBsonParser.java
+++ b/src/main/java/org/mongojack/internal/stream/DBDecoderBsonParser.java
@@ -35,15 +35,14 @@ import tools.jackson.databind.ObjectMapper;
 public class DBDecoderBsonParser extends JsonParserAdapter {
 
     public DBDecoderBsonParser(
-        IOContext ctxt,
-        int jsonFeatures,
-        AbstractBsonReader reader,
-        ObjectMapper objectMapper,
-        final UuidRepresentation uuidRepresentation
-    ) {
+            ObjectReadContext readCtxt,
+            IOContext ctxt,
+            int jsonFeatures,
+            AbstractBsonReader reader,
+            ObjectMapper objectMapper,
+            final UuidRepresentation uuidRepresentation) {
         // Honor document length must be true
-        super(ctxt, jsonFeatures, reader, uuidRepresentation);
-        setCodec(objectMapper);
+        super(readCtxt, ctxt, jsonFeatures, reader, uuidRepresentation);
     }
 
     @Override

--- a/src/main/java/org/mongojack/internal/stream/DBEncoderBsonGenerator.java
+++ b/src/main/java/org/mongojack/internal/stream/DBEncoderBsonGenerator.java
@@ -40,12 +40,21 @@ import tools.jackson.core.io.IOContext;
  */
 public class DBEncoderBsonGenerator extends JsonGeneratorAdapter {
 
-    public DBEncoderBsonGenerator(int jsonFeatures, BsonWriter out, final UuidRepresentation uuidRepresentation) {
-        super(jsonFeatures, null, out, uuidRepresentation);
+    public DBEncoderBsonGenerator(
+            ObjectWriteContext context,
+            IOContext ioContext,
+            int jsonFeatures,
+            BsonWriter out,
+            final UuidRepresentation uuidRepresentation) {
+        super(context, ioContext, jsonFeatures, out, uuidRepresentation);
     }
 
-    public DBEncoderBsonGenerator(final BsonWriter writer, final UuidRepresentation uuidRepresentation) {
-        this(JsonGenerator.Feature.collectDefaults(), writer, uuidRepresentation);
+    public DBEncoderBsonGenerator(
+            ObjectWriteContext context,
+            IOContext ioContext,
+            final BsonWriter writer,
+            final UuidRepresentation uuidRepresentation) {
+        this(context, ioContext, StreamWriteFeature.collectDefaults(), writer, uuidRepresentation);
     }
 
     @Override
@@ -74,7 +83,7 @@ public class DBEncoderBsonGenerator extends JsonGeneratorAdapter {
             writeEndObject();
         } else {
             if (!DocumentSerializationUtils.writeKnownType(value, writer)) {
-                super._writeSimpleObject(value);
+                _objectWriteContext.writeValue(this, value);
             }
         }
         return this;

--- a/src/main/java/org/mongojack/internal/stream/DBEncoderBsonGenerator.java
+++ b/src/main/java/org/mongojack/internal/stream/DBEncoderBsonGenerator.java
@@ -16,18 +16,23 @@
  */
 package org.mongojack.internal.stream;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.mongodb.DBRef;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.UUID;
+
 import org.bson.BsonBinary;
 import org.bson.BsonWriter;
 import org.bson.UuidRepresentation;
 import org.bson.types.ObjectId;
 import org.mongojack.internal.util.DocumentSerializationUtils;
 
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.UUID;
+import com.mongodb.DBRef;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.core.io.IOContext;
 
 /**
  * BsonGenerator that adds a bit of functionality specific to DBEncoding to the
@@ -44,24 +49,26 @@ public class DBEncoderBsonGenerator extends JsonGeneratorAdapter {
     }
 
     @Override
-    protected void _writeSimpleObject(Object value) throws IOException {
-        if (value instanceof Date) {
+    public JsonGenerator writePOJO(Object value) throws JacksonException {
+        if (value == null) {
+            writeNull();
+        } else if (value instanceof Date) {
             writer.writeDateTime(((Date) value).getTime());
         } else if (value instanceof Calendar) {
             writer.writeDateTime(((Calendar) value).getTime().getTime());
         } else if (value instanceof ObjectId) {
             writeBsonObjectId((ObjectId) value);
         } else if (value instanceof UUID) {
-            writer.writeBinaryData(new BsonBinary((UUID)value, uuidRepresentation));
+            writer.writeBinaryData(new BsonBinary((UUID) value, uuidRepresentation));
         } else if (value instanceof DBRef) {
             DBRef dbRef = (DBRef) value;
             writeStartObject();
-            writeFieldName("$ref");
+            writeName("$ref");
             writeString(dbRef.getCollectionName());
-            writeFieldName("$id");
-            writeObject(dbRef.getId());
+            writeName("$id");
+            writePOJO(dbRef.getId());
             if (dbRef.getDatabaseName() != null) {
-                writeFieldName("$db");
+                writeName("$db");
                 writeString(dbRef.getDatabaseName());
             }
             writeEndObject();
@@ -70,5 +77,6 @@ public class DBEncoderBsonGenerator extends JsonGeneratorAdapter {
                 super._writeSimpleObject(value);
             }
         }
+        return this;
     }
 }

--- a/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonCodec.java
@@ -1,14 +1,10 @@
 package org.mongojack.internal.stream;
 
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationConfig;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
-import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 import org.bson.BsonDecimal128;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
@@ -34,10 +30,11 @@ import org.mongojack.internal.AnnotationHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.introspect.BeanPropertyDefinition;
+import tools.jackson.databind.ser.SerializationContextExt;
 
 @SuppressWarnings("WeakerAccess")
 public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, OverridableUuidRepresentationCodec<T> {
@@ -52,11 +49,10 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
     private final JacksonCodecRegistry jacksonCodecRegistry;
 
     public JacksonCodec(
-        JacksonEncoder<T> encoder,
-        JacksonDecoder<T> decoder,
-        final ObjectMapper objectMapper,
-        JacksonCodecRegistry jacksonCodecRegistry
-        ) {
+            JacksonEncoder<T> encoder,
+            JacksonDecoder<T> decoder,
+            final ObjectMapper objectMapper,
+            JacksonCodecRegistry jacksonCodecRegistry) {
         this.encoder = encoder;
         this.decoder = decoder;
         this.objectMapper = objectMapper;
@@ -100,16 +96,15 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
     @Override
     public Codec<T> withUuidRepresentation(final UuidRepresentation uuidRepresentation) {
         return new JacksonCodec<>(
-            encoder.withUuidRepresentation(uuidRepresentation),
-            decoder.withUuidRepresentation(uuidRepresentation),
-            objectMapper,
-            jacksonCodecRegistry
-        );
+                encoder.withUuidRepresentation(uuidRepresentation),
+                decoder.withUuidRepresentation(uuidRepresentation),
+                objectMapper,
+                jacksonCodecRegistry);
     }
 
     private Supplier<BsonValue> getIdReader(final T t) {
         final Optional<BeanPropertyDefinition> maybeBpd = getIdElementDeserializationDescription(t.getClass());
-        return maybeBpd.<Supplier<BsonValue>>map(beanPropertyDefinition -> () -> {
+        return maybeBpd.<Supplier<BsonValue>> map(beanPropertyDefinition -> () -> {
             try {
                 return constructIdValue(beanPropertyDefinition.getAccessor().getValue(t), maybeBpd);
             } catch (Exception e) {
@@ -121,13 +116,12 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
 
     private Consumer<BsonObjectId> getIdWriter(final T t) {
         final Optional<BeanPropertyDefinition> maybeBpd = getIdElementSerializationDescription(t.getClass());
-        return maybeBpd.<Consumer<BsonObjectId>>map(beanPropertyDefinition -> (bsonObjectId) -> {
+        return maybeBpd.<Consumer<BsonObjectId>> map(beanPropertyDefinition -> (bsonObjectId) -> {
             try {
                 if (bsonObjectId != null) {
                     beanPropertyDefinition.getNonConstructorMutator().setValue(
-                        t,
-                        extractIdValue(bsonObjectId, beanPropertyDefinition.getRawPrimaryType())
-                    );
+                            t,
+                            extractIdValue(bsonObjectId, beanPropertyDefinition.getRawPrimaryType()));
                 }
             } catch (Exception e) {
                 logger.warn("Suppressed error attempting to get writer for object id in " + t.getClass(), e);
@@ -137,7 +131,8 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
     }
 
     /**
-     * This is only used for GENERATING an object id, and since we are only interested in auto-generating ObjectIds, then we only have to
+     * This is only used for GENERATING an object id, and since we are only interested in auto-generating ObjectIds,
+     * then we only have to
      * deal with object ids here.
      *
      * @param value
@@ -209,59 +204,54 @@ public class JacksonCodec<T> implements Codec<T>, CollectibleCodec<T>, Overridab
 
     public Optional<BeanPropertyDefinition> getIdElementDeserializationDescription(final Class<?> documentClass) {
         return deSerializationBPDCache.computeIfAbsent(
-            documentClass,
-            (documentClazz) -> {
-                final DeserializationConfig deserializationConfig = objectMapper.getDeserializationConfig();
-                final BeanDescription beanDescription = deserializationConfig.introspect(deserializationConfig.constructType(documentClass));
+                documentClass,
+                (documentClazz) -> {
+                    var ctx = objectMapper._deserializationContext();
+                    final BeanDescription beanDescription = ctx.introspectBeanDescription(ctx.constructType(documentClass));
 
-                final Optional<BeanPropertyDefinition> found = beanDescription.findProperties().stream()
-                    .filter(
-                        bpd -> ("_id".equals(bpd.getName()) ||
-                                AnnotationHelper.hasIdAnnotation(bpd.getPrimaryMember())) &&
-                                bpd.getAccessor() != null
-                    )
-                    .findFirst();
+                    final Optional<BeanPropertyDefinition> found = beanDescription.findProperties().stream()
+                            .filter(
+                                    bpd -> ("_id".equals(bpd.getName()) ||
+                                            AnnotationHelper.hasIdAnnotation(bpd.getPrimaryMember())) &&
+                                            bpd.getAccessor() != null)
+                            .findFirst();
 
-                found.ifPresent(
-                    bpd -> {
-                        if (deserializationConfig.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) {
-                            bpd.getAccessor().fixAccess(true);
-                        }
-                    }
-                );
+                    found.ifPresent(
+                            bpd -> {
+                                if (ctx.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) {
+                                    bpd.getAccessor().fixAccess(true);
+                                }
+                            });
 
-                return found;
-            }
-        );
+                    return found;
+                });
     }
 
     public Optional<BeanPropertyDefinition> getIdElementSerializationDescription(final Class<?> documentClass) {
         return serializationBPDCache.computeIfAbsent(
-            documentClass,
-            (documentClazz) -> {
-                final SerializationConfig serializationConfig = objectMapper.getSerializationConfig();
-                final BeanDescription beanDescription = serializationConfig.introspect(serializationConfig.constructType(documentClass));
+                documentClass,
+                (documentClazz) -> {
+                    final SerializationContextExt serializationContext = objectMapper._serializationContext();
+                    final BeanDescription beanDescription = serializationContext.introspectBeanDescription(serializationContext.constructType(
+                            documentClass));
 
-                final Optional<BeanPropertyDefinition> found = beanDescription.findProperties().stream()
-                    .filter(bpd -> bpd.getPrimaryMember() != null)
-                    .filter(
-                        bpd -> ("_id".equals(bpd.getName()) ||
-                                AnnotationHelper.hasIdAnnotation(bpd.getPrimaryMember())) &&
-                                bpd.getMutator() != null
-                    )
-                    .findFirst();
+                    final Optional<BeanPropertyDefinition> found = beanDescription.findProperties().stream()
+                            .filter(bpd -> bpd.getPrimaryMember() != null)
+                            .filter(
+                                    bpd -> ("_id".equals(bpd.getName()) ||
+                                            AnnotationHelper.hasIdAnnotation(bpd.getPrimaryMember())) &&
+                                            bpd.getMutator() != null)
+                            .findFirst();
 
-                found.ifPresent(
-                    bpd -> {
-                        if (serializationConfig.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) {
-                            bpd.getMutator().fixAccess(true);
-                        }
-                    }
-                );
+                    found.ifPresent(
+                            bpd -> {
+                                if (serializationContext.isEnabled(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)) {
+                                    bpd.getMutator().fixAccess(true);
+                                }
+                            });
 
-                return found;
-            }
-        );
+                    return found;
+                });
     }
 
 }

--- a/src/main/java/org/mongojack/internal/stream/JacksonDecoder.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonDecoder.java
@@ -1,16 +1,17 @@
 package org.mongojack.internal.stream;
 
-import com.fasterxml.jackson.core.io.IOContext;
-import com.fasterxml.jackson.core.util.BufferRecycler;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
+
 import org.bson.AbstractBsonReader;
 import org.bson.BsonReader;
 import org.bson.UuidRepresentation;
 import org.bson.codecs.Decoder;
 import org.bson.codecs.DecoderContext;
 
-import java.io.IOException;
-import java.io.InputStream;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.io.ContentReference;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.databind.ObjectMapper;
 
 public class JacksonDecoder<T> implements Decoder<T> {
 

--- a/src/main/java/org/mongojack/internal/stream/JacksonDecoder.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonDecoder.java
@@ -31,19 +31,28 @@ public class JacksonDecoder<T> implements Decoder<T> {
 
     public JacksonDecoder<T> withUuidRepresentation(final UuidRepresentation uuidRepresentation) {
         return new JacksonDecoder<>(
-            clazz,
-            view,
-            objectMapper,
-            uuidRepresentation
-        );
+                clazz,
+                view,
+                objectMapper,
+                uuidRepresentation);
     }
 
     @Override
     public T decode(BsonReader reader, DecoderContext decoderContext) {
-        try (DBDecoderBsonParser parser = new DBDecoderBsonParser(new IOContext(new BufferRecycler(), EMPTY_INPUT_STREAM, false), 0, (AbstractBsonReader) reader, objectMapper, uuidRepresentation)) {
+        var context = objectMapper._deserializationContext();
+        var ioCtx = new IOContext(
+                context.tokenStreamFactory().streamReadConstraints(),
+                context.tokenStreamFactory().streamWriteConstraints(),
+                context.tokenStreamFactory().errorReportConfiguration(),
+                context.tokenStreamFactory()._getBufferRecycler(),
+                ContentReference.unknown(),
+                false,
+                null);
+        try (DBDecoderBsonParser parser = new DBDecoderBsonParser(context, ioCtx, 0,
+                (AbstractBsonReader) reader, objectMapper, uuidRepresentation)) {
             return objectMapper.reader().forType(clazz).withView(view).readValue(parser);
-        } catch (IOException e) {
-            throw new RuntimeException("IOException encountered while parsing", e);
+        } catch (JacksonException e) {
+            throw new RuntimeException("JacksonException encountered while parsing", e);
         }
     }
 

--- a/src/main/java/org/mongojack/internal/stream/JacksonEncoder.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonEncoder.java
@@ -31,20 +31,28 @@ public class JacksonEncoder<T> implements Encoder<T> {
 
     public JacksonEncoder<T> withUuidRepresentation(final UuidRepresentation uuidRepresentation) {
         return new JacksonEncoder<>(
-            clazz,
-            view,
-            objectMapper,
-            uuidRepresentation
-        );
+                clazz,
+                view,
+                objectMapper,
+                uuidRepresentation);
     }
 
     @Override
     public void encode(BsonWriter writer, T value, EncoderContext encoderContext) {
-        try(JsonGenerator generator = new DBEncoderBsonGenerator(writer, uuidRepresentation)) {
+        var context = objectMapper._serializationContext();
+        var ioContext = new IOContext(
+                context.tokenStreamFactory().streamReadConstraints(),
+                context.tokenStreamFactory().streamWriteConstraints(),
+                context.tokenStreamFactory().errorReportConfiguration(),
+                context.tokenStreamFactory()._getBufferRecycler(),
+                ContentReference.unknown(),
+                false,
+                null);
+        try (JsonGenerator generator = new DBEncoderBsonGenerator(context, ioContext, writer, uuidRepresentation)) {
             objectMapper.writerWithView(view).writeValue(generator, value);
-        } catch (JsonMappingException e) {
-            throw new MongoJsonMappingException(e);
-        } catch (IOException e) {
+        } catch (DatabindException e) {
+            throw new MongoDatabindException(e);
+        } catch (JacksonException e) {
             throw new MongoException("Error writing object out", e);
         }
     }

--- a/src/main/java/org/mongojack/internal/stream/JacksonEncoder.java
+++ b/src/main/java/org/mongojack/internal/stream/JacksonEncoder.java
@@ -1,16 +1,19 @@
 package org.mongojack.internal.stream;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.MongoException;
 import org.bson.BsonWriter;
 import org.bson.UuidRepresentation;
 import org.bson.codecs.Encoder;
 import org.bson.codecs.EncoderContext;
-import org.mongojack.MongoJsonMappingException;
+import org.mongojack.MongoDatabindException;
 
-import java.io.IOException;
+import com.mongodb.MongoException;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.io.ContentReference;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.ObjectMapper;
 
 public class JacksonEncoder<T> implements Encoder<T> {
 

--- a/src/main/java/org/mongojack/internal/stream/JsonGeneratorAdapter.java
+++ b/src/main/java/org/mongojack/internal/stream/JsonGeneratorAdapter.java
@@ -1,125 +1,147 @@
 package org.mongojack.internal.stream;
 
-import com.fasterxml.jackson.core.Base64Variant;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.base.GeneratorBase;
-import com.fasterxml.jackson.core.json.JsonWriteContext;
-import org.bson.BsonBinary;
-import org.bson.BsonValue;
-import org.bson.BsonWriter;
-import org.bson.UuidRepresentation;
-import org.bson.types.Decimal128;
-import org.bson.types.ObjectId;
-import org.mongojack.internal.util.DocumentSerializationUtils;
-
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import org.bson.BsonBinary;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.UuidRepresentation;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+import org.mongojack.internal.MongoJackModule;
+import org.mongojack.internal.util.DocumentSerializationUtils;
+
+import tools.jackson.core.Base64Variant;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.StreamWriteCapability;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.Version;
+import tools.jackson.core.base.GeneratorBase;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.core.util.JacksonFeatureSet;
+
 public class JsonGeneratorAdapter extends GeneratorBase {
 
     protected final BsonWriter writer;
     protected final UuidRepresentation uuidRepresentation;
 
-    protected JsonGeneratorAdapter(final int features, final ObjectCodec codec, final BsonWriter writer,
-        final UuidRepresentation uuidRepresentation) {
-        super(features, codec);
-        this.writer = writer;
-        this.uuidRepresentation = uuidRepresentation;
-    }
-    
-
-    protected JsonGeneratorAdapter(final int features, final ObjectCodec codec, final JsonWriteContext ctxt, final BsonWriter writer,
-        final UuidRepresentation uuidRepresentation) {
-        super(features, codec, ctxt);
+    protected JsonGeneratorAdapter(
+            final ObjectWriteContext writeCtxt,
+            final IOContext ioCtxt,
+            final int streamWriteFeatures,
+            final BsonWriter writer,
+            final UuidRepresentation uuidRepresentation) {
+        super(writeCtxt, ioCtxt, streamWriteFeatures);
         this.writer = writer;
         this.uuidRepresentation = uuidRepresentation;
     }
 
     @Override
-    public void writeStartArray() throws IOException {
+    public JsonGenerator writeStartArray() throws JacksonException {
         writer.writeStartArray();
+        return this;
     }
 
     @Override
-    public void writeEndArray() throws IOException {
+    public JsonGenerator writeEndArray() throws JacksonException {
         writer.writeEndArray();
+        return this;
     }
 
     @Override
-    public void writeStartObject() throws IOException {
+    public JsonGenerator writeStartObject() throws JacksonException {
         writer.writeStartDocument();
+        return this;
     }
 
     @Override
-    public void writeEndObject() throws IOException {
+    public JsonGenerator writeEndObject() throws JacksonException {
         writer.writeEndDocument();
+        return this;
     }
 
     @Override
-    public void writeFieldName(final String name) throws IOException {
+    public JsonGenerator writeName(final String name) throws JacksonException {
         writer.writeName(name);
+        return this;
     }
 
     @Override
-    public void writeString(final String text) throws IOException {
+    public JsonGenerator writeString(final String text) throws JacksonException {
         writer.writeString(text);
+        return this;
     }
 
     @Override
-    public void writeString(final char[] text, final int offset, final int len) throws IOException {
+    public JsonGenerator writeString(final char[] text, final int offset, final int len) throws JacksonException {
         writer.writeString(new String(text, offset, len));
+        return this;
     }
 
     @Override
-    public void writeRawUTF8String(final byte[] text, final int offset, final int length) throws IOException {
+    public JsonGenerator writeRawUTF8String(final byte[] text, final int offset, final int length) throws JacksonException {
         writer.writeString(new String(text, offset, length, StandardCharsets.UTF_8));
+        return this;
     }
 
     @Override
-    public void writeUTF8String(final byte[] text, final int offset, final int length) throws IOException {
+    public JsonGenerator writeUTF8String(final byte[] text, final int offset, final int length) throws JacksonException {
         writer.writeString(new String(text, offset, length, StandardCharsets.UTF_8));
+        return this;
     }
 
     @Override
-    public void writeRaw(final String text) throws IOException {
+    public JsonGenerator writeRaw(final String text) throws JacksonException {
         throw new UnsupportedOperationException("writeRaw not supported");
     }
 
     @Override
-    public void writeRaw(final String text, final int offset, final int len) throws IOException {
+    public JsonGenerator writeRaw(final String text, final int offset, final int len) throws JacksonException {
         throw new UnsupportedOperationException("writeRaw not supported");
     }
 
     @Override
-    public void writeRaw(final char[] text, final int offset, final int len) throws IOException {
+    public JsonGenerator writeRaw(final char[] text, final int offset, final int len) throws JacksonException {
         throw new UnsupportedOperationException("writeRaw not supported");
     }
 
     @Override
-    public void writeRaw(final char c) throws IOException {
+    public JsonGenerator writeRaw(final char c) throws JacksonException {
         throw new UnsupportedOperationException("writeRaw not supported");
     }
 
     @Override
-    public void writeBinary(final Base64Variant bv, final byte[] data, final int offset, final int len) throws IOException {
+    public JsonGenerator writeBinary(final Base64Variant bv, final byte[] data, final int offset, final int len) throws JacksonException {
         writer.writeBinaryData(new BsonBinary(Arrays.copyOfRange(data, offset, len)));
+        return this;
     }
 
     @Override
-    public void writeNumber(final int v) throws IOException {
+    public JsonGenerator writeNumber(final short v) throws JacksonException {
         writer.writeInt32(v);
+        return this;
     }
 
     @Override
-    public void writeNumber(final long v) throws IOException {
+    public JsonGenerator writeNumber(final int v) throws JacksonException {
+        writer.writeInt32(v);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNumber(final long v) throws JacksonException {
         writer.writeInt64(v);
+        return this;
     }
 
     @Override
-    public void writeNumber(final BigInteger v) throws IOException {
+    public JsonGenerator writeNumber(final BigInteger v) throws JacksonException {
         int bl = v.bitLength();
         if (bl < 32) {
             writeNumber(v.intValue());
@@ -128,50 +150,59 @@ public class JsonGeneratorAdapter extends GeneratorBase {
         } else {
             writeString(v.toString());
         }
+        return this;
     }
 
     @Override
-    public void writeNumber(final double v) throws IOException {
+    public JsonGenerator writeNumber(final double v) throws JacksonException {
         writer.writeDouble(v);
+        return this;
     }
 
     @Override
-    public void writeNumber(final float v) throws IOException {
-        writeNumber((double)v);
+    public JsonGenerator writeNumber(final float v) throws JacksonException {
+        writeNumber((double) v);
+        return this;
     }
 
     @Override
-    public void writeNumber(final BigDecimal v) throws IOException {
+    public JsonGenerator writeNumber(final BigDecimal v) throws JacksonException {
         writer.writeDecimal128(new Decimal128(v));
+        return this;
     }
 
     @Override
-    public void writeNumber(final String encodedValue) throws IOException {
+    public JsonGenerator writeNumber(final String encodedValue) throws JacksonException {
         writeString(encodedValue);
+        return this;
     }
 
     @Override
-    public void writeBoolean(final boolean state) throws IOException {
+    public JsonGenerator writeBoolean(final boolean state) throws JacksonException {
         writer.writeBoolean(state);
+        return this;
     }
 
     @Override
-    public void writeNull() throws IOException {
+    public JsonGenerator writeNull() throws JacksonException {
         writer.writeNull();
+        return this;
     }
 
-    public void writeBsonObjectId(final ObjectId objectId) {
+    public JsonGenerator writeBsonObjectId(final ObjectId objectId) {
         writer.writeObjectId(objectId);
+        return this;
     }
 
-    public void writeBsonValue(final BsonValue value) {
+    public JsonGenerator writeBsonValue(final BsonValue value) {
         if (!DocumentSerializationUtils.writeKnownType(value, writer)) {
             throw new IllegalStateException("Asked to write unknown type " + value.getClass());
         }
+        return this;
     }
 
     @Override
-    public void flush() throws IOException {
+    public void flush() throws JacksonException {
         writer.flush();
     }
 
@@ -182,7 +213,7 @@ public class JsonGeneratorAdapter extends GeneratorBase {
     }
 
     @Override
-    protected void _verifyValueWrite(final String typeMsg) throws IOException {
+    protected void _verifyValueWrite(final String typeMsg) throws JacksonException {
         // no implementation
     }
 

--- a/src/main/java/org/mongojack/internal/stream/JsonGeneratorAdapter.java
+++ b/src/main/java/org/mongojack/internal/stream/JsonGeneratorAdapter.java
@@ -217,4 +217,65 @@ public class JsonGeneratorAdapter extends GeneratorBase {
         // no implementation
     }
 
+    @Override
+    protected void _closeInput() throws IOException {
+    }
+
+    @Override
+    public Version version() {
+        return MongoJackModule.DEFAULT_MODULE_INSTANCE.version();
+    }
+
+    @Override
+    public TokenStreamContext streamWriteContext() {
+        return null;
+    }
+
+    @Override
+    public Object streamWriteOutputTarget() {
+        return null;
+    }
+
+    @Override
+    public int streamWriteOutputBuffered() {
+        return 0;
+    }
+
+    protected Object _currentValue = null;
+
+    @Override
+    public Object currentValue() {
+        return _currentValue;
+    }
+
+    @Override
+    public void assignCurrentValue(Object v) {
+        _currentValue = v;
+    }
+
+    @Override
+    public JacksonFeatureSet<StreamWriteCapability> streamWriteCapabilities() {
+        return DEFAULT_TEXTUAL_WRITE_CAPABILITIES;
+    }
+
+    @Override
+    public JsonGenerator writeStartArray(Object currentValue) throws JacksonException {
+        this._currentValue = currentValue;
+        writeStartArray();
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeStartObject(Object currentValue) throws JacksonException {
+        this._currentValue = currentValue;
+        writeStartObject();
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writePropertyId(long id) throws JacksonException {
+        writeName(Long.toString(id));
+        return this;
+    }
+
 }

--- a/src/main/java/org/mongojack/internal/stream/JsonParserAdapter.java
+++ b/src/main/java/org/mongojack/internal/stream/JsonParserAdapter.java
@@ -48,6 +48,8 @@ public class JsonParserAdapter extends ParserBase {
 
     private final UuidRepresentation uuidRepresentation;
 
+    private SimpleStreamReadContext parserContext;
+
     /**
      * Constructs a new parser
      *
@@ -56,20 +58,16 @@ public class JsonParserAdapter extends ParserBase {
      *            {@link tools.jackson.core.JsonParser.Feature}s are enabled.
      * @param reader Bson reader to read from
      */
-    public JsonParserAdapter(IOContext ctxt, int jsonFeatures, AbstractBsonReader reader, final UuidRepresentation uuidRepresentation) {
-        super(ctxt, jsonFeatures);
+    public JsonParserAdapter(
+            ObjectReadContext readCtxt,
+            IOContext ctxt,
+            int jsonFeatures,
+            AbstractBsonReader reader,
+            final UuidRepresentation uuidRepresentation) {
+        super(readCtxt, ctxt, jsonFeatures);
+        this.parserContext = SimpleStreamReadContext.createRootContext(null);
         this.reader = reader;
         this.uuidRepresentation = uuidRepresentation;
-    }
-
-    @Override
-    public ObjectCodec getCodec() {
-        return _codec;
-    }
-
-    @Override
-    public void setCodec(ObjectCodec c) {
-        _codec = c;
     }
 
     @Override
@@ -372,6 +370,11 @@ public class JsonParserAdapter extends ParserBase {
     @Override
     protected void _closeInput() {
         reader.close();
+    }
+
+    @Override
+    public TokenStreamContext streamReadContext() {
+        return parserContext;
     }
 
     private AbstractBsonReader.State state() {

--- a/src/main/java/org/mongojack/internal/stream/JsonParserAdapter.java
+++ b/src/main/java/org/mongojack/internal/stream/JsonParserAdapter.java
@@ -16,6 +16,7 @@ import org.bson.codecs.BsonJavaScriptWithScopeCodec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.PatternCodec;
 import org.bson.types.Symbol;
+import org.mongojack.MongoDatabindException;
 import org.mongojack.internal.MongoJackModule;
 
 import com.mongodb.MongoClientSettings;
@@ -392,5 +393,81 @@ public class JsonParserAdapter extends ParserBase {
             }
             return existing;
         });
+    }
+
+    @Override
+    protected void _parseNumericValue(int expType) throws JacksonException, InputCoercionException {
+        switch (type()) {
+            case DECIMAL128:
+                currentValue = reader.readDecimal128();
+                break;
+            case DOUBLE:
+                currentValue = reader.readDouble();
+                break;
+            case INT32:
+                currentValue = reader.readInt32();
+                break;
+            case INT64:
+                currentValue = reader.readInt64();
+                break;
+            default:
+                throw new MongoDatabindException("Trying to parse a numeric value, but current token is not numeric, is " + type());
+        }
+    }
+
+    @Override
+    protected int _parseIntValue() throws JacksonException {
+        switch (type()) {
+            case INT32:
+                return reader.readInt32();
+            default:
+                throw new MongoDatabindException("Trying to parse an int value, but current token is not int32, is " + type());
+        }
+    }
+
+    @Override
+    public Version version() {
+        return MongoJackModule.DEFAULT_MODULE_INSTANCE.version();
+    }
+
+    @Override
+    public Object streamReadInputSource() {
+        return null;
+    }
+
+    @Override
+    public String getString() throws JacksonException {
+        if (_currToken == null) {
+            return null;
+        }
+        // need to separate handling a bit...
+        switch (_currToken) {
+            case PROPERTY_NAME:
+                return currentName();
+            case VALUE_STRING:
+                return (String) currentValue;
+            case VALUE_NUMBER_INT:
+            case VALUE_NUMBER_FLOAT:
+                return String.valueOf((Number) currentValue);
+            case VALUE_EMBEDDED_OBJECT:
+                return null;
+            default:
+                return _currToken.asString();
+        }
+    }
+
+    @Override
+    public char[] getStringCharacters() throws JacksonException {
+        return getString().toCharArray();
+    }
+
+    @Override
+    public int getStringLength() throws JacksonException {
+        return getString().length();
+    }
+
+    @Override
+    public int getStringOffset() throws JacksonException {
+        return 0;
     }
 }

--- a/src/main/java/org/mongojack/internal/stream/JsonParserAdapter.java
+++ b/src/main/java/org/mongojack/internal/stream/JsonParserAdapter.java
@@ -1,14 +1,10 @@
 package org.mongojack.internal.stream;
 
-import com.fasterxml.jackson.core.Base64Variant;
-import com.fasterxml.jackson.core.JsonLocation;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.base.ParserBase;
-import com.fasterxml.jackson.core.io.IOContext;
-import com.mongodb.MongoClientSettings;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.bson.AbstractBsonReader;
 import org.bson.BsonBinary;
 import org.bson.BsonBinarySubType;
@@ -20,16 +16,27 @@ import org.bson.codecs.BsonJavaScriptWithScopeCodec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.PatternCodec;
 import org.bson.types.Symbol;
+import org.mongojack.internal.MongoJackModule;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Date;
-import java.util.concurrent.atomic.AtomicReference;
+import com.mongodb.MongoClientSettings;
+
+import tools.jackson.core.Base64Variant;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.core.Version;
+import tools.jackson.core.base.ParserBase;
+import tools.jackson.core.exc.InputCoercionException;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.io.ContentReference;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.core.util.SimpleStreamReadContext;
 
 public class JsonParserAdapter extends ParserBase {
-
-    protected ObjectCodec _codec;
 
     protected final AbstractBsonReader reader;
 
@@ -44,10 +51,10 @@ public class JsonParserAdapter extends ParserBase {
     /**
      * Constructs a new parser
      *
-     * @param ctxt         the Jackson IO context
+     * @param ctxt the Jackson IO context
      * @param jsonFeatures bit flag composed of bits that indicate which
-     *                     {@link com.fasterxml.jackson.core.JsonParser.Feature}s are enabled.
-     * @param reader       Bson reader to read from
+     *            {@link tools.jackson.core.JsonParser.Feature}s are enabled.
+     * @param reader Bson reader to read from
      */
     public JsonParserAdapter(IOContext ctxt, int jsonFeatures, AbstractBsonReader reader, final UuidRepresentation uuidRepresentation) {
         super(ctxt, jsonFeatures);
@@ -67,18 +74,18 @@ public class JsonParserAdapter extends ParserBase {
 
     @Override
     public void close() {
-        if (isEnabled(JsonParser.Feature.AUTO_CLOSE_SOURCE)) {
+        if (isEnabled(StreamReadFeature.AUTO_CLOSE_SOURCE)) {
             reader.close();
         }
         _closed = true;
     }
 
     @Override
-    public JsonToken nextToken() throws IOException {
+    public JsonToken nextToken() throws JacksonException {
         return _currToken = _nextToken();
     }
 
-    private JsonToken _nextToken() throws IOException {
+    private JsonToken _nextToken() throws JacksonException {
         currentValue = null;
 
         while (state() == AbstractBsonReader.State.TYPE) {
@@ -90,8 +97,8 @@ public class JsonParserAdapter extends ParserBase {
                 reader.readStartDocument();
                 return JsonToken.START_OBJECT;
             case NAME:
-                getParsingContext().setCurrentName(reader.readName());
-                return JsonToken.FIELD_NAME;
+                ((SimpleStreamReadContext) streamReadContext()).setCurrentName(reader.readName());
+                return JsonToken.PROPERTY_NAME;
             case VALUE:
                 return toJsonToken(type());
             case END_OF_DOCUMENT:
@@ -103,15 +110,14 @@ public class JsonParserAdapter extends ParserBase {
             case DONE:
                 return null;
             default:
-                throw new JsonParseException(
-                    this,
-                    "Unknown state " + state(),
-                    getTokenLocation()
-                );
+                throw new StreamReadException(
+                        this,
+                        "Unknown state " + state(),
+                        currentTokenLocation());
         }
     }
 
-    protected JsonToken toJsonToken(BsonType type) throws IOException {
+    protected JsonToken toJsonToken(BsonType type) throws JacksonException {
         switch (type) {
             case END_OF_DOCUMENT:
                 reader.readEndDocument();
@@ -189,85 +195,78 @@ public class JsonParserAdapter extends ParserBase {
                 currentValue = value;
                 return value ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE;
             default:
-                throw new JsonParseException(
-                    this,
-                    "Unknown element type " + type,
-                    getTokenLocation()
-                );
+                throw new StreamReadException(
+                        this,
+                        "Unknown element type " + type,
+                        currentTokenLocation());
         }
     }
 
     @Override
-    public String nextFieldName() throws IOException {
-        if (nextToken() == JsonToken.FIELD_NAME) {
-            return getParsingContext().getCurrentName();
+    public String nextName() throws JacksonException {
+        if (nextToken() == JsonToken.PROPERTY_NAME) {
+            return streamReadContext().currentName();
         }
         return null;
     }
 
     @Override
-    public String getCurrentName() throws IOException {
+    public String currentName() throws JacksonException {
         if (state() == AbstractBsonReader.State.NAME) {
-            return nextFieldName();
+            return nextName();
         } else if (state() == AbstractBsonReader.State.VALUE) {
             final String currentName = reader.getCurrentName();
-            getParsingContext().setCurrentName(currentName);
+            parserContext.setCurrentName(currentName);
             return currentName;
         }
-        return getParsingContext().getCurrentName();
+        return streamReadContext().currentName();
     }
 
     @Override
-    public JsonLocation getTokenLocation() {
+    public TokenStreamLocation currentTokenLocation() {
         String currentName;
         try {
-            currentName = getCurrentName();
-        } catch (IOException e) {
+            currentName = currentName();
+        } catch (JacksonException e) {
             currentName = "unknown";
         }
-        return new JsonLocation(currentName, -1L, -1, -1);
+        return new TokenStreamLocation(ContentReference.rawReference(currentName), -1L, -1, -1);
     }
 
     @Override
-    public JsonLocation getCurrentLocation() {
+    public TokenStreamLocation currentLocation() {
         String currentName;
         try {
-            currentName = getCurrentName();
-        } catch (IOException e) {
+            currentName = currentName();
+        } catch (JacksonException e) {
             currentName = "unknown";
         }
-        return new JsonLocation(currentName, -1L, -1, -1);
+        return new TokenStreamLocation(ContentReference.rawReference(currentName), -1L, -1, -1);
     }
 
     @Override
-    public String getText() throws IOException {
-        if (currentToken() == JsonToken.FIELD_NAME) {
-            return getCurrentName();
+    public String getText() throws JacksonException {
+        if (currentToken() == JsonToken.PROPERTY_NAME) {
+            return currentName();
         }
         return String.valueOf(currentValue);
     }
 
     @Override
-    public char[] getTextCharacters() throws IOException {
-        //not very efficient; that's why hasTextCharacters()
-        //always returns false
+    public char[] getTextCharacters() throws JacksonException {
+        // not very efficient; that's why hasTextCharacters()
+        // always returns false
         return getText().toCharArray();
     }
 
     @Override
-    public int getTextLength() throws IOException {
+    public int getTextLength() throws JacksonException {
         return getText().length();
     }
 
     @Override
     public int getTextOffset() {
         return 0;
-    }
-
-    @Override
-    public boolean hasTextCharacters() {
-        //getTextCharacters is obviously not the most efficient way
-        return false;
     }
 
     @Override
@@ -280,7 +279,7 @@ public class JsonParserAdapter extends ParserBase {
     }
 
     @Override
-    public Object getNumberValueDeferred() throws IOException {
+    public Object getNumberValueDeferred() throws JacksonException {
         return getNumberValue();
     }
 
@@ -322,7 +321,7 @@ public class JsonParserAdapter extends ParserBase {
             return null;
         }
         if (n instanceof Byte || n instanceof Integer ||
-            n instanceof Long || n instanceof Short) {
+                n instanceof Long || n instanceof Short) {
             return BigInteger.valueOf(n.longValue());
         } else if (n instanceof Double || n instanceof Float) {
             return BigDecimal.valueOf(n.doubleValue()).toBigInteger();
@@ -347,7 +346,7 @@ public class JsonParserAdapter extends ParserBase {
             return null;
         }
         if (n instanceof Byte || n instanceof Integer ||
-            n instanceof Long || n instanceof Short) {
+                n instanceof Long || n instanceof Short) {
             return BigDecimal.valueOf(n.longValue());
         } else if (n instanceof Double || n instanceof Float) {
             return BigDecimal.valueOf(n.doubleValue());
@@ -366,7 +365,7 @@ public class JsonParserAdapter extends ParserBase {
     }
 
     @Override
-    protected void _handleEOF() throws JsonParseException {
+    protected void _handleEOF() throws StreamReadException {
         _reportInvalidEOF();
     }
 

--- a/src/main/java/org/mongojack/internal/stream/OutputBufferOutputStream.java
+++ b/src/main/java/org/mongojack/internal/stream/OutputBufferOutputStream.java
@@ -16,7 +16,7 @@
  */
 package org.mongojack.internal.stream;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 import java.io.OutputStream;
 
 import org.bson.io.OutputBuffer;
@@ -33,13 +33,13 @@ public class OutputBufferOutputStream extends OutputStream {
     }
 
     @Override
-    public void write(int b) throws IOException {
+    public void write(int b) throws JacksonException {
         outputBuffer.write(b);
         count++;
     }
 
     @Override
-    public void write(byte[] b, int off, int len) throws IOException {
+    public void write(byte[] b, int off, int len) throws JacksonException {
         outputBuffer.write(b, off, len);
         count += len;
     }

--- a/src/main/java/org/mongojack/internal/util/DistinctIterableDecorator.java
+++ b/src/main/java/org/mongojack/internal/util/DistinctIterableDecorator.java
@@ -1,7 +1,7 @@
 package org.mongojack.internal.util;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
 import com.mongodb.Function;
 import com.mongodb.client.DistinctIterable;
 import com.mongodb.client.MongoCursor;

--- a/src/main/java/org/mongojack/internal/util/DocumentSerializationUtils.java
+++ b/src/main/java/org/mongojack/internal/util/DocumentSerializationUtils.java
@@ -16,8 +16,8 @@
  */
 package org.mongojack.internal.util;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
 import org.bson.BsonWriter;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;

--- a/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsApi.java
+++ b/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsApi.java
@@ -16,8 +16,8 @@
  */
 package org.mongojack.internal.util;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
 import org.bson.BsonWriter;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;

--- a/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsImpl.java
+++ b/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsImpl.java
@@ -349,19 +349,27 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
     @SuppressWarnings("rawtypes")
     @Override
     public Bson serializeFilter(
-        ObjectMapper objectMapper,
-        JavaType type,
-        Bson query,
-        CodecRegistry registry
-    ) {
-        SerializerProvider serializerProvider = JacksonAccessor.getSerializerProvider(objectMapper);
-        JsonSerializer serializer = JacksonAccessor.findValueSerializer(
-            serializerProvider, type);
+            ObjectMapper objectMapper,
+            JavaType type,
+            Bson query,
+            CodecRegistry registry) {
+        SerializationContext serializerProvider = objectMapper._serializationContext();
+        ValueSerializer serializer = JacksonAccessor.findValueSerializer(
+                serializerProvider, type);
+        var context = objectMapper._serializationContext();
+        var ioContext = new IOContext(
+                context.tokenStreamFactory().streamReadConstraints(),
+                context.tokenStreamFactory().streamWriteConstraints(),
+                context.tokenStreamFactory().errorReportConfiguration(),
+                context.tokenStreamFactory()._getBufferRecycler(),
+                ContentReference.unknown(),
+                false,
+                null);
         final BsonDocument document = new BsonDocument();
         try (
-            BsonDocumentWriter writer = new BsonDocumentWriter(document);
-            DBEncoderBsonGenerator generator = new DBEncoderBsonGenerator(writer, attemptToExtractUuidRepresentation(registry))
-        ) {
+                BsonDocumentWriter writer = new BsonDocumentWriter(document);
+                DBEncoderBsonGenerator generator = new DBEncoderBsonGenerator(context, ioContext, writer, attemptToExtractUuidRepresentation(
+                        registry))) {
             serializeFilter(serializerProvider, serializer, query, registry, writer, generator);
             return document;
         } catch (Exception e) {
@@ -500,20 +508,28 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
 
     @Override
     public Bson serializeUpdates(
-        Map<String, Map<String, UpdateOperationValue>> update,
-        ObjectMapper objectMapper,
-        JavaType javaType,
-        CodecRegistry registry
-    ) {
-        SerializerProvider serializerProvider = JacksonAccessor.getSerializerProvider(objectMapper);
+            Map<String, Map<String, UpdateOperationValue>> update,
+            ObjectMapper objectMapper,
+            JavaType javaType,
+            CodecRegistry registry) {
+        SerializationContext serializerProvider = objectMapper._serializationContext();
 
-        JsonSerializer<?> serializer = JacksonAccessor.findValueSerializer(serializerProvider, javaType);
+        ValueSerializer<?> serializer = JacksonAccessor.findValueSerializer(serializerProvider, javaType);
+        var context = objectMapper._serializationContext();
+        var ioContext = new IOContext(
+                context.tokenStreamFactory().streamReadConstraints(),
+                context.tokenStreamFactory().streamWriteConstraints(),
+                context.tokenStreamFactory().errorReportConfiguration(),
+                context.tokenStreamFactory()._getBufferRecycler(),
+                ContentReference.unknown(),
+                false,
+                null);
 
         final BsonDocument document = new BsonDocument();
         try (
-            BsonDocumentWriter writer = new BsonDocumentWriter(document);
-            DBEncoderBsonGenerator generator = new DBEncoderBsonGenerator(writer, attemptToExtractUuidRepresentation(registry))
-        ) {
+                BsonDocumentWriter writer = new BsonDocumentWriter(document);
+                DBEncoderBsonGenerator generator = new DBEncoderBsonGenerator(context, ioContext, writer, attemptToExtractUuidRepresentation(
+                        registry))) {
             writer.writeStartDocument();
             for (Entry<String, Map<String, UpdateOperationValue>> op : update.entrySet()) {
                 writer.writeName(op.getKey());

--- a/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsImpl.java
+++ b/src/main/java/org/mongojack/internal/util/DocumentSerializationUtilsImpl.java
@@ -16,15 +16,39 @@
  */
 package org.mongojack.internal.util;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.ContainerSerializer;
-import com.fasterxml.jackson.databind.ser.std.AsArraySerializerBase;
-import com.fasterxml.jackson.databind.ser.std.BeanSerializerBase;
-import com.fasterxml.jackson.databind.ser.std.MapSerializer;
-import org.bson.*;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonDocumentWriter;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonMaxKey;
+import org.bson.BsonMinKey;
+import org.bson.BsonObjectId;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonString;
+import org.bson.BsonSymbol;
+import org.bson.BsonTimestamp;
+import org.bson.BsonUndefined;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.Document;
+import org.bson.UuidRepresentation;
 import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.UuidCodec;
@@ -34,18 +58,24 @@ import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.mongojack.DBRef;
 import org.mongojack.JacksonCodecRegistry;
-import org.mongojack.MongoJsonMappingException;
+import org.mongojack.MongoDatabindException;
 import org.mongojack.UpdateOperationValue;
 import org.mongojack.internal.ObjectIdSerializer;
 import org.mongojack.internal.stream.DBEncoderBsonGenerator;
 import org.mongojack.internal.update.MultiUpdateOperationValue;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.io.ContentReference;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.ser.bean.BeanSerializerBase;
+import tools.jackson.databind.ser.jdk.MapSerializer;
+import tools.jackson.databind.ser.std.AsArraySerializerBase;
+import tools.jackson.databind.ser.std.StdContainerSerializer;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 /**
  * Utilities for helping with serialisation
@@ -88,15 +118,14 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
      * Serialize the fields of the given object using the given object mapper.
      * This will convert POJOs to Documents where necessary.
      *
-     * @param object   The object to serialize the fields of
+     * @param object The object to serialize the fields of
      * @param registry Codec registry
      * @return The Document, safe for serialization to MongoDB
      */
     @Override
     public Bson serializeFields(
-        Bson object,
-        CodecRegistry registry
-    ) {
+            Bson object,
+            CodecRegistry registry) {
         return object.toBsonDocument(Document.class, registry);
     }
 
@@ -106,12 +135,11 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     protected void serializeQueryField(
-        Object value,
-        JsonSerializer serializer,
-        SerializerProvider serializerProvider,
-        BsonDocumentWriter writer,
-        DBEncoderBsonGenerator generator
-    ) throws IOException {
+            Object value,
+            ValueSerializer serializer,
+            SerializationContext serializerProvider,
+            BsonDocumentWriter writer,
+            DBEncoderBsonGenerator generator) throws JacksonException {
         if (value == null) {
             writer.writeNull();
             return;
@@ -140,8 +168,8 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
         }
 
         if (serializer.handledType() != null &&
-            !serializer.handledType().isAssignableFrom(value.getClass()) &&
-            (BASIC_TYPES.contains(value.getClass()) || value instanceof BsonValue)) {
+                !serializer.handledType().isAssignableFrom(value.getClass()) &&
+                (BASIC_TYPES.contains(value.getClass()) || value instanceof BsonValue)) {
             if (writeKnownType(value, writer)) {
                 return;
             }
@@ -155,9 +183,8 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
 
     @Override
     public boolean writeKnownType(
-        Object value,
-        BsonWriter writer
-    ) {
+            Object value,
+            BsonWriter writer) {
         if (value instanceof String) {
             writer.writeString((String) value);
         } else if (value instanceof Integer) {
@@ -244,38 +271,37 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
     @SuppressWarnings({"RedundantIfStatement", "unused"})
     @Override
     public boolean isKnownType(
-        Object value
-    ) {
+            Object value) {
         if (value instanceof String ||
-            value instanceof Integer ||
-            value instanceof Boolean ||
-            value instanceof Short ||
-            value instanceof Long ||
-            value instanceof BigInteger ||
-            value instanceof Float ||
-            value instanceof Double ||
-            value instanceof Byte ||
-            value instanceof BigDecimal ||
-            value instanceof UUID ||
-            value instanceof byte[] ||
-            value instanceof Date ||
-            value instanceof Pattern ||
-            value instanceof ObjectId ||
-            value instanceof BsonSymbol ||
-            value instanceof BsonObjectId ||
-            value instanceof BsonBoolean ||
-            value instanceof BsonString ||
-            value instanceof BsonMaxKey ||
-            value instanceof BsonMinKey ||
-            value instanceof BsonInt64 ||
-            value instanceof BsonInt32 ||
-            value instanceof BsonDouble ||
-            value instanceof BsonDecimal128 ||
-            value instanceof BsonDateTime ||
-            value instanceof BsonTimestamp ||
-            value instanceof BsonUndefined ||
-            value instanceof BsonRegularExpression ||
-            value instanceof BsonBinary) {
+                value instanceof Integer ||
+                value instanceof Boolean ||
+                value instanceof Short ||
+                value instanceof Long ||
+                value instanceof BigInteger ||
+                value instanceof Float ||
+                value instanceof Double ||
+                value instanceof Byte ||
+                value instanceof BigDecimal ||
+                value instanceof UUID ||
+                value instanceof byte[] ||
+                value instanceof Date ||
+                value instanceof Pattern ||
+                value instanceof ObjectId ||
+                value instanceof BsonSymbol ||
+                value instanceof BsonObjectId ||
+                value instanceof BsonBoolean ||
+                value instanceof BsonString ||
+                value instanceof BsonMaxKey ||
+                value instanceof BsonMinKey ||
+                value instanceof BsonInt64 ||
+                value instanceof BsonInt32 ||
+                value instanceof BsonDouble ||
+                value instanceof BsonDecimal128 ||
+                value instanceof BsonDateTime ||
+                value instanceof BsonTimestamp ||
+                value instanceof BsonUndefined ||
+                value instanceof BsonRegularExpression ||
+                value instanceof BsonBinary) {
             return true;
         }
         return false;
@@ -284,38 +310,37 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
     @SuppressWarnings("RedundantIfStatement")
     @Override
     public boolean isKnownClass(
-        Class<?> value
-    ) {
+            Class<?> value) {
         if (value.equals(String.class) ||
-            value.equals(Integer.class) ||
-            value.equals(Boolean.class) ||
-            value.equals(Short.class) ||
-            value.equals(Long.class) ||
-            value.equals(BigInteger.class) ||
-            value.equals(Float.class) ||
-            value.equals(Double.class) ||
-            value.equals(Byte.class) ||
-            value.equals(BigDecimal.class) ||
-            value.equals(UUID.class) ||
-            value.equals(byte[].class) ||
-            value.equals(Date.class) ||
-            value.equals(Pattern.class) ||
-            value.equals(ObjectId.class) ||
-            value.equals(BsonSymbol.class) ||
-            value.equals(BsonObjectId.class) ||
-            value.equals(BsonBoolean.class) ||
-            value.equals(BsonString.class) ||
-            value.equals(BsonMaxKey.class) ||
-            value.equals(BsonMinKey.class) ||
-            value.equals(BsonInt64.class) ||
-            value.equals(BsonInt32.class) ||
-            value.equals(BsonDouble.class) ||
-            value.equals(BsonDecimal128.class) ||
-            value.equals(BsonDateTime.class) ||
-            value.equals(BsonTimestamp.class) ||
-            value.equals(BsonUndefined.class) ||
-            value.equals(BsonRegularExpression.class) ||
-            value.equals(BsonBinary.class)) {
+                value.equals(Integer.class) ||
+                value.equals(Boolean.class) ||
+                value.equals(Short.class) ||
+                value.equals(Long.class) ||
+                value.equals(BigInteger.class) ||
+                value.equals(Float.class) ||
+                value.equals(Double.class) ||
+                value.equals(Byte.class) ||
+                value.equals(BigDecimal.class) ||
+                value.equals(UUID.class) ||
+                value.equals(byte[].class) ||
+                value.equals(Date.class) ||
+                value.equals(Pattern.class) ||
+                value.equals(ObjectId.class) ||
+                value.equals(BsonSymbol.class) ||
+                value.equals(BsonObjectId.class) ||
+                value.equals(BsonBoolean.class) ||
+                value.equals(BsonString.class) ||
+                value.equals(BsonMaxKey.class) ||
+                value.equals(BsonMinKey.class) ||
+                value.equals(BsonInt64.class) ||
+                value.equals(BsonInt32.class) ||
+                value.equals(BsonDouble.class) ||
+                value.equals(BsonDecimal128.class) ||
+                value.equals(BsonDateTime.class) ||
+                value.equals(BsonTimestamp.class) ||
+                value.equals(BsonUndefined.class) ||
+                value.equals(BsonRegularExpression.class) ||
+                value.equals(BsonBinary.class)) {
             return true;
         }
         return false;
@@ -357,25 +382,24 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
 
     @SuppressWarnings("unchecked")
     protected void serializeFilter(
-        SerializerProvider serializerProvider,
-        JsonSerializer<?> serializer,
-        Bson query,
-        CodecRegistry registry,
-        BsonDocumentWriter writer,
-        DBEncoderBsonGenerator generator
-    ) throws IOException {
-        // not sure this is the best way to do it.  But you can't get anything out of a Bson but a BsonDocument...
-        final Map<String, Object> decoded = registry.get(Map.class).decode(new BsonDocumentReader(query.toBsonDocument(Document.class, registry)), DecoderContext.builder().build());
+            SerializationContext serializerProvider,
+            ValueSerializer<?> serializer,
+            Bson query,
+            CodecRegistry registry,
+            BsonDocumentWriter writer,
+            DBEncoderBsonGenerator generator) throws JacksonException {
+        // not sure this is the best way to do it. But you can't get anything out of a Bson but a BsonDocument...
+        final Map<String, Object> decoded = registry.get(Map.class).decode(new BsonDocumentReader(query.toBsonDocument(Document.class, registry)),
+                DecoderContext.builder().build());
         serializeFilter(serializerProvider, serializer, decoded, writer, generator);
     }
 
     protected void serializeFilter(
-        final SerializerProvider serializerProvider,
-        final JsonSerializer<?> serializer,
-        final Map<String, Object> decoded,
-        BsonDocumentWriter writer,
-        DBEncoderBsonGenerator generator
-    ) throws IOException {
+            final SerializationContext serializerProvider,
+            final ValueSerializer<?> serializer,
+            final Map<String, Object> decoded,
+            BsonDocumentWriter writer,
+            DBEncoderBsonGenerator generator) throws JacksonException {
         writer.writeStartDocument();
         for (Entry<String, Object> field : decoded.entrySet()) {
             String key = field.getKey();
@@ -388,14 +412,13 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
 
     @SuppressWarnings("unchecked")
     protected void serializeFilterCondition(
-        SerializerProvider serializerProvider,
-        JsonSerializer<?> serializer,
-        String key,
-        Object condition,
-        boolean targetIsCollection,
-        BsonDocumentWriter writer,
-        DBEncoderBsonGenerator generator
-    ) throws IOException {
+            SerializationContext serializerProvider,
+            ValueSerializer<?> serializer,
+            String key,
+            Object condition,
+            boolean targetIsCollection,
+            BsonDocumentWriter writer,
+            DBEncoderBsonGenerator generator) throws JacksonException {
         if (condition instanceof Collection) {
             if (keyIsNotOperator(key)) {
                 serializer = findQuerySerializer(targetIsCollection, key, serializerProvider, serializer);
@@ -423,19 +446,19 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
     /**
      * Serialize the given field
      *
-     * @param value              The value to serialize
-     * @param serializerProvider A SerializerProvider
-     * @param registry           The codec registry to be used for serialization
+     * @param value The value to serialize
+     * @param serializerProvider A SerializationContext
+     * @param registry The codec registry to be used for serialization
      */
     @SuppressWarnings("unchecked")
     protected void serializeUpdateField(
-        Object value,
-        SerializerProvider serializerProvider,
-        BsonDocumentWriter writer,
-        DBEncoderBsonGenerator generator,
-        CodecRegistry registry
-    ) throws IOException {
-        @SuppressWarnings("rawtypes") JsonSerializer serializer;
+            Object value,
+            SerializationContext serializerProvider,
+            BsonDocumentWriter writer,
+            DBEncoderBsonGenerator generator,
+            CodecRegistry registry) throws JacksonException {
+        @SuppressWarnings("rawtypes")
+        ValueSerializer serializer;
         if (value == null) {
             writer.writeNull();
             return;
@@ -465,8 +488,8 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
         }
 
         if (serializer.handledType() != null &&
-            !serializer.handledType().isAssignableFrom(value.getClass()) &&
-            (BASIC_TYPES.contains(value.getClass()) || value instanceof BsonValue)) {
+                !serializer.handledType().isAssignableFrom(value.getClass()) &&
+                (BASIC_TYPES.contains(value.getClass()) || value instanceof BsonValue)) {
             if (writeKnownType(value, writer)) {
                 return;
             }
@@ -499,38 +522,34 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
                     writer.writeName(field.getKey());
                     boolean subDocument = false;
                     if ((op.getKey().equals("$addToSet") || op.getKey().equals("$push"))
-                        && field.getValue() instanceof MultiUpdateOperationValue) {
+                            && field.getValue() instanceof MultiUpdateOperationValue) {
                         subDocument = true;
                         writer.writeStartDocument();
                         writer.writeName("$each");
                     }
                     if (field.getValue().requiresSerialization()) {
-                        JsonSerializer<?> fieldSerializer = findUpdateSerializer(
-                            field.getValue().isTargetCollection(),
-                            field.getKey(),
-                            serializerProvider,
-                            serializer
-                        );
+                        ValueSerializer<?> fieldSerializer = findUpdateSerializer(
+                                field.getValue().isTargetCollection(),
+                                field.getKey(),
+                                serializerProvider,
+                                serializer);
                         if (fieldSerializer != null) {
                             serializeUpdateField(
-                                field.getValue(),
-                                fieldSerializer,
-                                serializerProvider,
-                                writer,
-                                generator
-                            );
+                                    field.getValue(),
+                                    fieldSerializer,
+                                    serializerProvider,
+                                    writer,
+                                    generator);
                         } else {
                             // Try default serializers
                             serializeUpdateField(
-                                field.getValue().getValue(),
-                                serializerProvider, writer, generator, registry
-                            );
+                                    field.getValue().getValue(),
+                                    serializerProvider, writer, generator, registry);
                         }
                     } else {
                         serializeUpdateField(
-                            field.getValue().getValue(),
-                            serializerProvider, writer, generator, registry
-                        );
+                                field.getValue().getValue(),
+                                serializerProvider, writer, generator, registry);
                     }
                     if (subDocument) {
                         writer.writeEndDocument();
@@ -540,56 +559,51 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
             }
             writer.writeEndDocument();
             return document;
-        } catch (IOException e) {
-            throw new MongoJsonMappingException(e.getMessage(), e);
+        } catch (JacksonException e) {
+            throw new MongoDatabindException(e.getMessage(), e);
         }
     }
 
     protected void serializeUpdateField(
-        UpdateOperationValue value,
-        JsonSerializer<?> serializer,
-        SerializerProvider serializerProvider,
-        BsonDocumentWriter writer,
-        DBEncoderBsonGenerator generator
-    ) throws IOException {
+            UpdateOperationValue value,
+            ValueSerializer<?> serializer,
+            SerializationContext serializerProvider,
+            BsonDocumentWriter writer,
+            DBEncoderBsonGenerator generator) throws JacksonException {
         if (value instanceof MultiUpdateOperationValue) {
             writer.writeStartArray();
             for (Object item : ((MultiUpdateOperationValue) value).getValues()) {
                 serializeUpdateField(
-                    item,
-                    serializer,
-                    serializerProvider,
-                    generator
-                );
+                        item,
+                        serializer,
+                        serializerProvider,
+                        generator);
             }
             writer.writeEndArray();
         } else {
             serializeUpdateField(
-                value.getValue(),
-                serializer,
-                serializerProvider,
-                generator
-            );
+                    value.getValue(),
+                    serializer,
+                    serializerProvider,
+                    generator);
         }
     }
 
     @SuppressWarnings("unchecked")
     protected void serializeUpdateField(
-        Object value,
-        @SuppressWarnings("rawtypes") JsonSerializer serializer,
-        SerializerProvider serializerProvider,
-        DBEncoderBsonGenerator generator
-    ) throws IOException {
+            Object value,
+            @SuppressWarnings("rawtypes") ValueSerializer serializer,
+            SerializationContext serializerProvider,
+            DBEncoderBsonGenerator generator) throws JacksonException {
         serializer.serialize(value, generator, serializerProvider);
     }
 
     @SuppressWarnings({"rawtypes", "StatementWithEmptyBody"})
-    protected JsonSerializer<?> findUpdateSerializer(
-        boolean targetIsCollection, String fieldPath,
-        SerializerProvider serializerProvider, JsonSerializer<?> serializer
-    ) {
-        if (serializer instanceof BeanSerializerBase) {
-            JsonSerializer<?> fieldSerializer = serializer;
+    protected ValueSerializer<?> findUpdateSerializer(
+            boolean targetIsCollection, String fieldPath,
+            SerializationContext serializerProvider, ValueSerializer<?> serializer) {
+        if (serializer instanceof StdSerializer) {
+            ValueSerializer<?> fieldSerializer = serializer;
             // Iterate through the components of the field name
             String[] fields = fieldPath.split("\\.");
             for (String field : fields) {
@@ -600,14 +614,14 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
                 }
                 if (field.equals("$") || field.matches("\\d+")) {
                     // The current serializer must be a collection
-                    if (fieldSerializer instanceof ContainerSerializer) {
-                        fieldSerializer = getJsonSerializerForContainer(serializerProvider, fieldSerializer);
+                    if (fieldSerializer instanceof StdContainerSerializer) {
+                        fieldSerializer = getValueSerializerForContainer(serializerProvider, fieldSerializer);
                     } else {
                         // Give up, don't attempt to serialise it
                         return null;
                     }
                 } else if (fieldSerializer instanceof BeanSerializerBase) {
-                    JsonSerializer<?> temp = JacksonAccessor.findJsonSerializer(serializerProvider, (BeanSerializerBase) fieldSerializer, field);
+                    ValueSerializer<?> temp = JacksonAccessor.findValueSerializer(serializerProvider, (BeanSerializerBase) fieldSerializer, field);
                     if (temp != null) {
                         fieldSerializer = temp;
                     } else {
@@ -616,7 +630,7 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
                     }
                 } else if (fieldSerializer instanceof MapSerializer) {
                     fieldSerializer = ((MapSerializer) fieldSerializer)
-                        .getContentSerializer();
+                            .getContentSerializer();
                 } else {
                     // Don't know how to find what the serialiser for this field
                     // is
@@ -626,9 +640,9 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
             // Now we have a serializer for the field, see if we're supposed to
             // be serialising for a collection
             if (targetIsCollection) {
-                if (fieldSerializer instanceof ContainerSerializer) {
-                    fieldSerializer = ((ContainerSerializer) fieldSerializer)
-                        .getContentSerializer();
+                if (fieldSerializer instanceof StdContainerSerializer) {
+                    fieldSerializer = ((StdContainerSerializer) fieldSerializer)
+                            .getContentSerializer();
                 } else if (fieldSerializer instanceof ObjectIdSerializer) {
                     // Special case for ObjectIdSerializer, leave as is, the
                     // ObjectIdSerializer handles both single
@@ -645,17 +659,17 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
     }
 
     @SuppressWarnings("rawtypes")
-    protected JsonSerializer<?> getJsonSerializerForContainer(final SerializerProvider serializerProvider, JsonSerializer<?> fieldSerializer) {
-        JsonSerializer<?> contentSerializer = ((ContainerSerializer) fieldSerializer)
-            .getContentSerializer();
+    protected ValueSerializer<?> getValueSerializerForContainer(final SerializationContext serializerProvider, ValueSerializer<?> fieldSerializer) {
+        ValueSerializer<?> contentSerializer = ((StdContainerSerializer) fieldSerializer)
+                .getContentSerializer();
         if (contentSerializer == null) {
             // Work it out
-            JavaType contentType = ((ContainerSerializer) fieldSerializer)
-                .getContentType();
+            JavaType contentType = ((StdContainerSerializer) fieldSerializer)
+                    .getContentType();
             if (contentType != null) {
                 contentSerializer = JacksonAccessor
-                    .findValueSerializer(
-                        serializerProvider, contentType);
+                        .findValueSerializer(
+                                serializerProvider, contentType);
             }
         }
         fieldSerializer = contentSerializer;
@@ -663,13 +677,12 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
     }
 
     @SuppressWarnings({"StatementWithEmptyBody", "rawtypes"})
-    protected JsonSerializer<?> findQuerySerializer(
-        boolean targetIsCollection, String fieldPath,
-        SerializerProvider serializerProvider, JsonSerializer<?> serializer
-    ) {
+    protected ValueSerializer<?> findQuerySerializer(
+            boolean targetIsCollection, String fieldPath,
+            SerializationContext serializerProvider, ValueSerializer<?> serializer) {
         if (serializer instanceof BeanSerializerBase
-            || serializer instanceof MapSerializer) {
-            JsonSerializer<?> fieldSerializer = serializer;
+                || serializer instanceof MapSerializer) {
+            ValueSerializer<?> fieldSerializer = serializer;
             // Iterate through the components of the field name
             String[] fields = fieldPath.split("\\.");
             for (String field : fields) {
@@ -683,20 +696,20 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
 
                 // First step into the collection if there is one
                 if (!isIndex) {
-                    while (fieldSerializer instanceof ContainerSerializer) {
-                        fieldSerializer = getJsonSerializerForContainer(serializerProvider, fieldSerializer);
+                    while (fieldSerializer instanceof StdContainerSerializer) {
+                        fieldSerializer = getValueSerializerForContainer(serializerProvider, fieldSerializer);
                     }
                 }
 
                 if (isIndex) {
-                    if (fieldSerializer instanceof ContainerSerializer) {
-                        fieldSerializer = getJsonSerializerForContainer(serializerProvider, fieldSerializer);
+                    if (fieldSerializer instanceof StdContainerSerializer) {
+                        fieldSerializer = getValueSerializerForContainer(serializerProvider, fieldSerializer);
                     } else {
                         // Give up, don't attempt to serialise it
                         return null;
                     }
                 } else if (fieldSerializer instanceof BeanSerializerBase) {
-                    JsonSerializer<?> temp = JacksonAccessor.findJsonSerializer(serializerProvider, (BeanSerializerBase) fieldSerializer, field);
+                    ValueSerializer<?> temp = JacksonAccessor.findValueSerializer(serializerProvider, (BeanSerializerBase) fieldSerializer, field);
                     if (temp != null) {
                         fieldSerializer = temp;
                     } else {
@@ -712,9 +725,9 @@ public class DocumentSerializationUtilsImpl implements DocumentSerializationUtil
             // Now we have a serializer for the field, see if we're supposed to
             // be serialising for a collection
             if (targetIsCollection) {
-                if (fieldSerializer instanceof ContainerSerializer) {
-                    fieldSerializer = ((ContainerSerializer) fieldSerializer)
-                        .getContentSerializer();
+                if (fieldSerializer instanceof StdContainerSerializer) {
+                    fieldSerializer = ((StdContainerSerializer) fieldSerializer)
+                            .getContentSerializer();
                 } else if (fieldSerializer instanceof ObjectIdSerializer) {
                     // Special case for ObjectIdSerializer, leave as is, the
                     // ObjectIdSerializer handles both single

--- a/src/main/java/org/mongojack/internal/util/FindIterableDecorator.java
+++ b/src/main/java/org/mongojack/internal/util/FindIterableDecorator.java
@@ -1,7 +1,7 @@
 package org.mongojack.internal.util;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
 import com.mongodb.CursorType;
 import com.mongodb.ExplainVerbosity;
 import com.mongodb.Function;

--- a/src/main/java/org/mongojack/internal/util/JacksonAccessor.java
+++ b/src/main/java/org/mongojack/internal/util/JacksonAccessor.java
@@ -16,19 +16,18 @@
  */
 package org.mongojack.internal.util;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
-import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
-import com.fasterxml.jackson.databind.ser.impl.ObjectIdWriter;
-import com.fasterxml.jackson.databind.ser.std.BeanSerializerBase;
-
-import java.io.IOException;
 import java.util.Set;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.ser.BeanPropertyWriter;
+import tools.jackson.databind.ser.bean.BeanSerializerBase;
+import tools.jackson.databind.ser.impl.ObjectIdWriter;
+import tools.jackson.databind.util.NameTransformer;
 
 /**
  * Accesses things in Jackson that usually aren't accessible. Here be dragons.
@@ -43,11 +42,6 @@ public class JacksonAccessor {
 
         @Override
         public BeanSerializerBase withObjectIdWriter(final ObjectIdWriter objectIdWriter) {
-            throw new IllegalStateException("LocalBeanSerializer should never escape confinement");
-        }
-
-        @Override
-        protected BeanSerializerBase withIgnorals(final Set<String> toIgnore) {
             throw new IllegalStateException("LocalBeanSerializer should never escape confinement");
         }
 
@@ -70,7 +64,12 @@ public class JacksonAccessor {
         }
 
         @Override
-        public void serialize(final Object bean, final JsonGenerator gen, final SerializerProvider provider) throws IOException {
+        public void serialize(final Object bean, final JsonGenerator gen, final SerializationContext provider) throws JacksonException {
+            throw new IllegalStateException("LocalBeanSerializer should never escape confinement");
+        }
+
+        @Override
+        public ValueSerializer<Object> unwrappingSerializer(NameTransformer unwrapper) {
             throw new IllegalStateException("LocalBeanSerializer should never escape confinement");
         }
 
@@ -80,13 +79,12 @@ public class JacksonAccessor {
 
     }
 
-    public static JsonSerializer<?> findJsonSerializer(
-        SerializerProvider serializerProvider,
-        BeanSerializerBase serializer,
-        String propertyName
-    ) {
+    public static ValueSerializer<?> findValueSerializer(
+            SerializationContext serializerProvider,
+            BeanSerializerBase serializer,
+            String propertyName) {
         BeanPropertyWriter writer = findPropertyWriterByName(propertyName, new LocalBeanSerializer(serializer).getProps());
-        JsonSerializer<?> foundSerializer = null;
+        ValueSerializer<?> foundSerializer = null;
         if (writer != null) {
             foundSerializer = writer.getSerializer();
             if (foundSerializer == null) {
@@ -105,33 +103,20 @@ public class JacksonAccessor {
         return null;
     }
 
-    public static SerializerProvider getSerializerProvider(
-        ObjectMapper objectMapper
-    ) {
-        DefaultSerializerProvider serializerProvider = (DefaultSerializerProvider) objectMapper
-            .getSerializerProvider();
-        return serializerProvider.createInstance(
-            objectMapper.getSerializationConfig(),
-            objectMapper.getSerializerFactory()
-        );
-    }
-
-    public static JsonSerializer findValueSerializer(
-        SerializerProvider serializerProvider, JavaType javaType
-    ) {
+    public static ValueSerializer findValueSerializer(
+            SerializationContext serializerProvider, JavaType javaType) {
         try {
-            return serializerProvider.findValueSerializer(javaType, null);
-        } catch (JsonMappingException e) {
+            return serializerProvider.findValueSerializer(javaType);
+        } catch (DatabindException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static JsonSerializer findValueSerializer(
-        SerializerProvider serializerProvider, Class clazz
-    ) {
+    public static ValueSerializer findValueSerializer(
+            SerializationContext serializerProvider, Class clazz) {
         try {
-            return serializerProvider.findValueSerializer(clazz, null);
-        } catch (JsonMappingException e) {
+            return serializerProvider.findValueSerializer(clazz);
+        } catch (DatabindException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/org/mongojack/internal/util/MapReduceIterableDecorator.java
+++ b/src/main/java/org/mongojack/internal/util/MapReduceIterableDecorator.java
@@ -1,7 +1,7 @@
 package org.mongojack.internal.util;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
 import com.mongodb.Function;
 import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoCursor;

--- a/src/main/java/org/mongojack/internal/util/MappingConsumer.java
+++ b/src/main/java/org/mongojack/internal/util/MappingConsumer.java
@@ -1,10 +1,10 @@
 package org.mongojack.internal.util;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
 @FunctionalInterface
 public interface MappingConsumer<T> {
 
-    void accept(T t) throws IOException;
+    void accept(T t) throws JacksonException;
 
 }

--- a/src/main/java/org/mongojack/internal/util/VersionUtils.java
+++ b/src/main/java/org/mongojack/internal/util/VersionUtils.java
@@ -16,25 +16,24 @@
  */
 package org.mongojack.internal.util;
 
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.core.util.VersionUtil;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+
+import tools.jackson.core.Version;
+import tools.jackson.core.util.VersionUtil;
 
 /**
  * Looks up the version of the MongoJack
  */
 public class VersionUtils {
-    
+
     public static final Version VERSION = mavenVersionFor(VersionUtils.class.getClassLoader(),
-        "org.mongojack", "mongojack"
-    );
+            "org.mongojack", "mongojack");
 
     private static Version mavenVersionFor(ClassLoader cl, String groupId, String artifactId) {
         InputStream pomProperties = cl.getResourceAsStream("META-INF/maven/"
-            + groupId.replaceAll("\\.", "/") + "/" + artifactId + "/pom.properties");
+                + groupId.replaceAll("\\.", "/") + "/" + artifactId + "/pom.properties");
         if (pomProperties != null) {
             try {
                 Properties props = new Properties();

--- a/src/test/java/org/mongojack/MongoDBTestBase.java
+++ b/src/test/java/org/mongojack/MongoDBTestBase.java
@@ -16,7 +16,7 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;

--- a/src/test/java/org/mongojack/TestBsonSerializers.java
+++ b/src/test/java/org/mongojack/TestBsonSerializers.java
@@ -1,25 +1,33 @@
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.client.model.Aggregates;
-import com.mongodb.client.model.Filters;
-import org.bson.*;
-import org.bson.conversions.Bson;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
 
 public class TestBsonSerializers extends MongoDBTestBase {
 
     private final ObjectMapper bsonSerializingObjectMapper = ObjectMapperConfigurer.configureObjectMapper(
-        new ObjectMapper(),
-        new MongoJackModuleConfiguration().with(MongoJackModuleFeature.ENABLE_BSON_VALUE_SERIALIZATION)
-    );
+            new ObjectMapper(),
+            new MongoJackModuleConfiguration().with(MongoJackModuleFeature.ENABLE_BSON_VALUE_SERIALIZATION));
 
     @Test
     public void testCollectionOfDocuments() {
@@ -118,25 +126,18 @@ public class TestBsonSerializers extends MongoDBTestBase {
 
         // we don't expect anything here, but it shouldn't throw an exception
         c
-            .aggregate(
-                List.of(
-                    new Document(
-                        "$unionWith",
-                        new Document("coll", "otherCollection")
-                            .append("pipeline",
-                                List.of(
-                                    Aggregates.match(
-                                        Filters.and(
-                                            Filters.eq("a", "a"),
-                                            Filters.eq("a", "c")
-                                        )
-                                    )
-                                )
-                            )
-                    )
-                )
-            )
-            .into(new ArrayList<>());
+                .aggregate(
+                        List.of(
+                                new Document(
+                                        "$unionWith",
+                                        new Document("coll", "otherCollection")
+                                                .append("pipeline",
+                                                        List.of(
+                                                                Aggregates.match(
+                                                                        Filters.and(
+                                                                                Filters.eq("a", "a"),
+                                                                                Filters.eq("a", "c"))))))))
+                .into(new ArrayList<>());
     }
 
     @Test
@@ -144,22 +145,16 @@ public class TestBsonSerializers extends MongoDBTestBase {
         JacksonMongoCollection<Document> c = getCollection(Document.class, bsonSerializingObjectMapper);
 
         c
-            .aggregate(
-                Arrays.asList(
-                    new Document("$match",
-                        new Document(
-                            "$and",
-                            Arrays.asList(
-                                new Document("receiver",
-                                    new Document("$exists", true)
-                                        .append("$ne", new BsonNull())
-                                )
-                            )
-                        )
-                    )
-                )
-            )
-            .into(new ArrayList<>());
+                .aggregate(
+                        Arrays.asList(
+                                new Document("$match",
+                                        new Document(
+                                                "$and",
+                                                Arrays.asList(
+                                                        new Document("receiver",
+                                                                new Document("$exists", true)
+                                                                        .append("$ne", new BsonNull())))))))
+                .into(new ArrayList<>());
     }
 
     @Test
@@ -167,28 +162,20 @@ public class TestBsonSerializers extends MongoDBTestBase {
         JacksonMongoCollection<Document> c = getCollection(Document.class);
 
         assertThrows(
-            MongoJsonMappingException.class,
-            () -> c
-                .aggregate(
-                    List.of(
-                        new Document(
-                            "$unionWith",
-                            new Document("coll", "otherCollection")
-                                .append("pipeline",
-                                    List.of(
-                                        Aggregates.match(
-                                            Filters.and(
-                                                Filters.eq("a", "a"),
-                                                Filters.eq("a", "c")
-                                            )
-                                        )
-                                    )
-                                )
-                        )
-                    )
-                )
-                .into(new ArrayList<>()),
-            "Expected aggregation to throw MongoJsonMappingException, but didn't"
-        );
+                MongoDatabindException.class,
+                () -> c
+                        .aggregate(
+                                List.of(
+                                        new Document(
+                                                "$unionWith",
+                                                new Document("coll", "otherCollection")
+                                                        .append("pipeline",
+                                                                List.of(
+                                                                        Aggregates.match(
+                                                                                Filters.and(
+                                                                                        Filters.eq("a", "a"),
+                                                                                        Filters.eq("a", "c"))))))))
+                        .into(new ArrayList<>()),
+                "Expected aggregation to throw MongoDatabindException, but didn't");
     }
 }

--- a/src/test/java/org/mongojack/TestBsonSerializers.java
+++ b/src/test/java/org/mongojack/TestBsonSerializers.java
@@ -159,7 +159,11 @@ public class TestBsonSerializers extends MongoDBTestBase {
 
     @Test
     public void testAggregationWithFailingListWithoutCustomObjectMapper() {
-        JacksonMongoCollection<Document> c = getCollection(Document.class);
+        // ensure the serializer is not found, by failing on missing serializers
+        // and asserting that the operation throws
+        var mapper = ObjectMapperConfigurer.configureObjectMapper(new ObjectMapper())
+                .rebuild().enable(SerializationFeature.FAIL_ON_EMPTY_BEANS).build();
+        JacksonMongoCollection<Document> c = getCollection(Document.class, mapper);
 
         assertThrows(
                 MongoDatabindException.class,

--- a/src/test/java/org/mongojack/TestCustomObjectMapper.java
+++ b/src/test/java/org/mongojack/TestCustomObjectMapper.java
@@ -173,9 +173,8 @@ public class TestCustomObjectMapper extends MongoDBTestBase {
             }
         });
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(module);
-        ObjectMapperConfigurer.configureObjectMapper(objectMapper);
+        ObjectMapper objectMapper = JsonMapper.builder().addModule(module).build();
+        objectMapper = ObjectMapperConfigurer.configureObjectMapper(objectMapper);
         return objectMapper;
     }
 

--- a/src/test/java/org/mongojack/TestCustomObjectMapper.java
+++ b/src/test/java/org/mongojack/TestCustomObjectMapper.java
@@ -16,32 +16,34 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.KeyDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
-import org.bson.Document;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.Version;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.KeyDeserializer;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 public class TestCustomObjectMapper extends MongoDBTestBase {
 
@@ -96,13 +98,11 @@ public class TestCustomObjectMapper extends MongoDBTestBase {
         obj.uriStringMap.put(URI.create("baz$qux"), "002");
 
         coll.updateOne(
-            Filters.eq(obj.id),
-            Updates.combine(
-                Updates.set("custom", obj.custom),
-                Updates.set("uriStringMap", obj.uriStringMap)
-            ),
-            new UpdateOptions().upsert(true)
-        );
+                Filters.eq(obj.id),
+                Updates.combine(
+                        Updates.set("custom", obj.custom),
+                        Updates.set("uriStringMap", obj.uriStringMap)),
+                new UpdateOptions().upsert(true));
 
         MockObject saved = coll.findOne();
         assertNotNull(saved);
@@ -135,41 +135,41 @@ public class TestCustomObjectMapper extends MongoDBTestBase {
     private ObjectMapper createObjectMapper() {
         SimpleModule module = new SimpleModule("MySimpleModule", new Version(1,
                 0, 0, null, "", ""));
-        module.addDeserializer(Custom.class, new JsonDeserializer<Custom>() {
+        module.addDeserializer(Custom.class, new ValueDeserializer<Custom>() {
             @Override
             public Custom deserialize(JsonParser jp, DeserializationContext ctxt)
-                    throws IOException {
+                    throws JacksonException {
                 JsonNode node = jp.readValueAsTree();
                 return new Custom(node.get("v1").asText(), node.get("v2")
                         .asText());
             }
         });
-        module.addSerializer(Custom.class, new JsonSerializer<Custom>() {
+        module.addSerializer(Custom.class, new ValueSerializer<Custom>() {
             @Override
             public void serialize(Custom value, JsonGenerator jgen,
-                    SerializerProvider provider) throws IOException {
+                    SerializationContext provider) throws JacksonException {
                 jgen.writeStartObject();
-                jgen.writeFieldName("v1");
+                jgen.writeName("v1");
                 jgen.writeString(value.value1);
-                jgen.writeFieldName("v2");
+                jgen.writeName("v2");
                 jgen.writeString(value.value2);
                 jgen.writeEndObject();
             }
         });
-        module.addKeySerializer(URI.class, new JsonSerializer<URI>() {
+        module.addKeySerializer(URI.class, new ValueSerializer<URI>() {
             @Override
-            public void serialize(final URI value, final JsonGenerator gen, final SerializerProvider serializers) throws IOException {
+            public void serialize(final URI value, final JsonGenerator gen, final SerializationContext serializers) throws JacksonException {
                 if (value == null) {
                     gen.writeNull();
                 } else {
-                    gen.writeFieldName(value.toString().replace(".", "%2E").replace("$","%24"));
+                    gen.writeName(value.toString().replace(".", "%2E").replace("$", "%24"));
                 }
             }
         });
         module.addKeyDeserializer(URI.class, new KeyDeserializer() {
             @Override
-            public Object deserializeKey(final String key, final DeserializationContext ctxt) throws IOException {
-                return URI.create(key.replace("%2E",".").replace("%24","$"));
+            public Object deserializeKey(final String key, final DeserializationContext ctxt) throws JacksonException {
+                return URI.create(key.replace("%2E", ".").replace("%24", "$"));
             }
         });
 

--- a/src/test/java/org/mongojack/TestDBUpdateSerialization.java
+++ b/src/test/java/org/mongojack/TestDBUpdateSerialization.java
@@ -16,18 +16,18 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JsonSerialize;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -187,11 +187,11 @@ public class TestDBUpdateSerialization extends MongoDBTestBase {
         public List<String> objectIds;
     }
 
-    public static class FooToBarSerializer extends JsonSerializer<String> {
+    public static class FooToBarSerializer extends ValueSerializer<String> {
         @Override
         public void serialize(String value, JsonGenerator jgen,
-                              SerializerProvider provider) throws IOException,
-            JsonProcessingException {
+                              SerializationContext provider) throws JacksonException,
+            JacksonException {
             if ("foo".equals(value)) {
                 jgen.writeString("bar");
             } else {

--- a/src/test/java/org/mongojack/TestIdAnnotatedClass.java
+++ b/src/test/java/org/mongojack/TestIdAnnotatedClass.java
@@ -16,18 +16,20 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationConfig;
-import com.mongodb.client.model.Filters;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.bson.Document;
 import org.bson.codecs.pojo.annotations.BsonId;
 import org.junit.jupiter.api.Test;
 import org.mongojack.internal.MongoJackModule;
 import org.mongojack.mock.IdProxy;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.mongodb.client.model.Filters;
+
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ser.SerializationContextExt;
 
 public class TestIdAnnotatedClass extends MongoDBTestBase {
 
@@ -169,7 +171,7 @@ public class TestIdAnnotatedClass extends MongoDBTestBase {
     @Test
     public void testCreatorGetterObjectIdAnnotated() {
         CreatorGetterObjectIdAnnotated o = new CreatorGetterObjectIdAnnotated(
-            new org.bson.types.ObjectId().toString());
+                new org.bson.types.ObjectId().toString());
         JacksonMongoCollection<CreatorGetterObjectIdAnnotated> coll = createCollFor(o);
         coll.insert(o);
         CreatorGetterObjectIdAnnotated result = coll.findOneById(o.id);
@@ -232,12 +234,11 @@ public class TestIdAnnotatedClass extends MongoDBTestBase {
     public void testProxyFieldAnnotatedWithoutSettingIt() {
         ObjectMapper om = MongoJackModule.configure(new ObjectMapper());
 
-        final SerializationConfig config = om.getSerializationConfig();
-        final BeanDescription beanDescription = config.introspect(config.constructType(IdFieldProxyAnnotated.class));
+        final SerializationContextExt ctx = om._serializationContext();
+        final BeanDescription beanDescription = ctx.introspectBeanDescription(ctx.constructType(IdFieldProxyAnnotated.class));
         assertThat(beanDescription.findProperties()
-            .stream().filter(
-                bpd -> bpd.getPrimaryMember().hasAnnotation(ObjectId.class)
-            ).findFirst().get().getName()).isEqualTo("_id");
+                .stream().filter(
+                        bpd -> bpd.getPrimaryMember().hasAnnotation(ObjectId.class)).findFirst().get().getName()).isEqualTo("_id");
 
         IdFieldProxyAnnotated o = new IdFieldProxyAnnotated();
         JacksonMongoCollection<IdFieldProxyAnnotated> coll = createCollFor(o);
@@ -286,12 +287,11 @@ public class TestIdAnnotatedClass extends MongoDBTestBase {
     public void testProxyFieldAnnotatedWithoutSettingItSubclass() {
         ObjectMapper om = MongoJackModule.configure(new ObjectMapper());
 
-        final SerializationConfig config = om.getSerializationConfig();
-        final BeanDescription beanDescription = config.introspect(config.constructType(IdFieldProxyAnnotatedSubclass.class));
+        final SerializationContextExt ctx = om._serializationContext();
+        final BeanDescription beanDescription = ctx.introspectBeanDescription(ctx.constructType(IdFieldProxyAnnotatedSubclass.class));
         assertThat(beanDescription.findProperties()
-            .stream().filter(
-                bpd -> bpd.getPrimaryMember().hasAnnotation(ObjectId.class)
-            ).findFirst().get().getName()).isEqualTo("_id");
+                .stream().filter(
+                        bpd -> bpd.getPrimaryMember().hasAnnotation(ObjectId.class)).findFirst().get().getName()).isEqualTo("_id");
 
         IdFieldProxyAnnotatedSubclass o = new IdFieldProxyAnnotatedSubclass();
         JacksonMongoCollection<IdFieldProxyAnnotatedSubclass> coll = createCollFor(o);

--- a/src/test/java/org/mongojack/TestJacksonCodecRegistry.java
+++ b/src/test/java/org/mongojack/TestJacksonCodecRegistry.java
@@ -16,7 +16,7 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.ReturnDocument;

--- a/src/test/java/org/mongojack/TestJacksonMongoCollectionCustomObjectMapper.java
+++ b/src/test/java/org/mongojack/TestJacksonMongoCollectionCustomObjectMapper.java
@@ -112,9 +112,8 @@ public class TestJacksonMongoCollectionCustomObjectMapper extends MongoDBTestBas
             }
         });
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(module);
-        ObjectMapperConfigurer.configureObjectMapper(objectMapper);
+        ObjectMapper objectMapper = JsonMapper.builder().addModule(module).build();
+        objectMapper = ObjectMapperConfigurer.configureObjectMapper(objectMapper);
         return objectMapper;
     }
 

--- a/src/test/java/org/mongojack/TestJacksonMongoCollectionCustomObjectMapper.java
+++ b/src/test/java/org/mongojack/TestJacksonMongoCollectionCustomObjectMapper.java
@@ -16,20 +16,25 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.Version;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 public class TestJacksonMongoCollectionCustomObjectMapper extends MongoDBTestBase {
 
@@ -37,9 +42,9 @@ public class TestJacksonMongoCollectionCustomObjectMapper extends MongoDBTestBas
 
     @BeforeEach
     public void setUp() {
-        coll = JacksonMongoCollection.<MockObject>builder()
-            .withObjectMapper(createObjectMapper())
-            .build(getMongoCollection("testJacksonMongoCollection", MockObject.class), MockObject.class, uuidRepresentation);
+        coll = JacksonMongoCollection.<MockObject> builder()
+                .withObjectMapper(createObjectMapper())
+                .build(getMongoCollection("testJacksonMongoCollection", MockObject.class), MockObject.class, uuidRepresentation);
     }
 
     @Test
@@ -84,24 +89,24 @@ public class TestJacksonMongoCollectionCustomObjectMapper extends MongoDBTestBas
 
     private ObjectMapper createObjectMapper() {
         SimpleModule module = new SimpleModule("MySimpleModule", new Version(1,
-            0, 0, null, "", ""));
-        module.addDeserializer(Custom.class, new JsonDeserializer<Custom>() {
+                0, 0, null, "", ""));
+        module.addDeserializer(Custom.class, new ValueDeserializer<Custom>() {
             @Override
             public Custom deserialize(JsonParser jp, DeserializationContext ctxt)
-                throws IOException {
+                    throws JacksonException {
                 JsonNode node = jp.readValueAsTree();
                 return new Custom(node.get("v1").asText(), node.get("v2")
-                    .asText());
+                        .asText());
             }
         });
-        module.addSerializer(Custom.class, new JsonSerializer<Custom>() {
+        module.addSerializer(Custom.class, new ValueSerializer<Custom>() {
             @Override
             public void serialize(Custom value, JsonGenerator jgen,
-                                  SerializerProvider provider) throws IOException {
+                    SerializationContext provider) throws JacksonException {
                 jgen.writeStartObject();
-                jgen.writeFieldName("v1");
+                jgen.writeName("v1");
                 jgen.writeString(value.value1);
-                jgen.writeFieldName("v2");
+                jgen.writeName("v2");
                 jgen.writeString(value.value2);
                 jgen.writeEndObject();
             }

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -1,11 +1,7 @@
 package org.mongojack;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import org.bson.BsonDateTime;
-import org.bson.BsonDocument;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -23,9 +19,13 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
 
 /**
  * class TestJavaTimeHandling: Tests the java.time.* handling in MongoJack.

--- a/src/test/java/org/mongojack/TestJavaTimeHandling.java
+++ b/src/test/java/org/mongojack/TestJavaTimeHandling.java
@@ -41,13 +41,14 @@ public class TestJavaTimeHandling extends MongoDBTestBase {
         public org.bson.types.ObjectId _id;
         public LocalDate localDate;
     }
-    
+
     @BeforeEach
     public void setUp() {
-        timestampWritingObjectMapper = ObjectMapperConfigurer.configureObjectMapper(new ObjectMapper());
-        timestampWritingObjectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
-        millisWritingObjectMapper = ObjectMapperConfigurer.configureObjectMapper(new ObjectMapper(), new MongoJackModuleConfiguration().with(MongoJackModuleFeature.WRITE_INSTANT_AS_BSON_DATE));
-        millisWritingObjectMapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
+        timestampWritingObjectMapper = ObjectMapperConfigurer.configureObjectMapper(new ObjectMapper()).rebuild()
+                .configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, true).build();
+        millisWritingObjectMapper = ObjectMapperConfigurer.configureObjectMapper(new ObjectMapper(), new MongoJackModuleConfiguration().with(
+                MongoJackModuleFeature.WRITE_INSTANT_AS_BSON_DATE))
+                .rebuild().configure(DateTimeFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false).build();
     }
 
     @Test

--- a/src/test/java/org/mongojack/TestJsonViews.java
+++ b/src/test/java/org/mongojack/TestJsonViews.java
@@ -36,7 +36,7 @@ public class TestJsonViews extends MongoDBTestBase {
     @Test
     public void testNormalPropertyWithView() {
         coll.save(new ObjectWithView("id", "normal", "view1", "view2"));
-        assertThat(coll.findOneById("id").normal).isEqualTo("normal");
+        assertThat(coll.findOneById("id").normal).isNull();
     }
 
     @Test
@@ -63,7 +63,10 @@ public class TestJsonViews extends MongoDBTestBase {
         public ObjectWithView() {
         }
 
-        public ObjectWithView(String id, String normal, String view1,
+        public ObjectWithView(
+                String id,
+                String normal,
+                String view1,
                 String view2) {
             _id = id;
             this.normal = normal;

--- a/src/test/java/org/mongojack/TestJsonViews.java
+++ b/src/test/java/org/mongojack/TestJsonViews.java
@@ -16,13 +16,13 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.annotation.JsonView;
-import com.mongodb.client.model.Filters;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import com.fasterxml.jackson.annotation.JsonView;
+import com.mongodb.client.model.Filters;
 
 public class TestJsonViews extends MongoDBTestBase {
 

--- a/src/test/java/org/mongojack/TestObjectIdHandling.java
+++ b/src/test/java/org/mongojack/TestObjectIdHandling.java
@@ -16,14 +16,30 @@
  */
 package org.mongojack;
 
-import com.fasterxml.jackson.annotation.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.UUID;
+
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
+import org.mongojack.internal.EmbeddedObjectSerializer;
+import org.mongojack.internal.MongoJackModule;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 
-import java.util.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import tools.jackson.databind.ObjectMapper;
 
 @SuppressWarnings("ConstantConditions")
 public class TestObjectIdHandling extends MongoDBTestBase {
@@ -193,7 +209,7 @@ public class TestObjectIdHandling extends MongoDBTestBase {
         ByteArrayIdCollection object = new ByteArrayIdCollection();
         object._id = "id";
         object.list = Arrays.asList(org.bson.types.ObjectId.get().toByteArray(), org.bson.types.ObjectId.get()
-            .toByteArray());
+                .toByteArray());
 
         JacksonMongoCollection<ByteArrayIdCollection> coll = getCollection(ByteArrayIdCollection.class);
         coll.insert(object);
@@ -351,8 +367,10 @@ public class TestObjectIdHandling extends MongoDBTestBase {
 
         @Override
         public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             final ConvertibleId that = (ConvertibleId) o;
             return Objects.equals(value, that.value);
         }
@@ -453,8 +471,10 @@ public class TestObjectIdHandling extends MongoDBTestBase {
 
         @Override
         public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             final ComplexId complexId = (ComplexId) o;
             return Objects.equals(value1, complexId.value1) && Objects.equals(value2, complexId.value2);
         }
@@ -467,9 +487,9 @@ public class TestObjectIdHandling extends MongoDBTestBase {
         @Override
         public String toString() {
             return new StringJoiner(", ", ComplexId.class.getSimpleName() + "[", "]")
-                .add("value1='" + value1 + "'")
-                .add("value2='" + value2 + "'")
-                .toString();
+                    .add("value1='" + value1 + "'")
+                    .add("value2='" + value2 + "'")
+                    .toString();
         }
     }
 
@@ -558,7 +578,7 @@ public class TestObjectIdHandling extends MongoDBTestBase {
         private ObjectId id;
 
         @JsonCreator
-        public ObjectWithConstructorOnlyObjectId(@Id  ObjectId id) {
+        public ObjectWithConstructorOnlyObjectId(@Id ObjectId id) {
             this.id = id;
         }
 
@@ -573,6 +593,20 @@ public class TestObjectIdHandling extends MongoDBTestBase {
         public void setId(ObjectId id) {
             this.id = id;
         }
+    }
+
+    /**
+     * mapper.convertValue serializes into a TokenBuffer and then deserializes again. This excercises a code path in the
+     * {@link EmbeddedObjectSerializer} which serializes ObjectIds as an embedded object.
+     * 
+     */
+    @Test
+    public void testObjectIdSerializingViaTokenBuffer() throws JsonProcessingException {
+        var mapper = MongoJackModule.configure(new ObjectMapper());
+        var before = new org.bson.types.ObjectId();
+        var after = mapper.convertValue(before, org.bson.types.ObjectId.class);
+        assertEquals(before, after);
+
     }
 
 }

--- a/src/test/java/org/mongojack/TestParsingAndGeneratingPolymorphicTypes.java
+++ b/src/test/java/org/mongojack/TestParsingAndGeneratingPolymorphicTypes.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.mongodb.client.model.Filters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/mongojack/TestQuerySerialization.java
+++ b/src/test/java/org/mongojack/TestQuerySerialization.java
@@ -17,14 +17,14 @@
 package org.mongojack;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 import com.mongodb.DBRef;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
@@ -34,7 +34,7 @@ import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -435,30 +435,30 @@ public class TestQuerySerialization extends MongoDBTestBase {
         }
     }
 
-    static class PlusTenSerializer extends JsonSerializer<Integer> {
+    static class PlusTenSerializer extends ValueSerializer<Integer> {
         @Override
         public void serialize(
             Integer value, JsonGenerator jgen,
-            SerializerProvider provider
-        ) throws IOException {
+            SerializationContext provider
+        ) throws JacksonException {
             jgen.writeNumber(value + 10);
         }
     }
 
-    static class MinusTenDeserializer extends JsonDeserializer<Integer> {
+    static class MinusTenDeserializer extends ValueDeserializer<Integer> {
         @Override
         public Integer deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException {
+            throws JacksonException {
             return jp.getValueAsInt() - 10;
         }
     }
 
-    static class WrappedStringSerializer extends JsonSerializer<StringWrapper> {
+    static class WrappedStringSerializer extends ValueSerializer<StringWrapper> {
         @Override
         public void serialize(
             StringWrapper value, JsonGenerator jgen,
-            SerializerProvider provider
-        ) throws IOException {
+            SerializationContext provider
+        ) throws JacksonException {
             if (value == null) {
                 jgen.writeNull();
             } else {


### PR DESCRIPTION
Closes #252 

- Lots of search/replace according to the [migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md)
- Change module registration, because ObjectMappers are now immutable and use builders
- Replace ObjectCodec references with various context objects
- Implement new required methods on ParserBase and GeneratorBase
- Construct context objects for decoding/encoding
- Adjust to changed defaults
  - disableDeserializationFeature.FAIL_ON_TRAILING_TOKENS
  - allow getters with underscores (like get_id())
  - enable SerializationFeature.FAIL_ON_EMPTY_BEANS for some test
  - JsonViews exclude unannotated properties by default
- Require Java 17+

Things I am not 100% sure about:
- When decoding/encoding, I use the `ObjectMapper._deserializationContext()`/`ObjectMapper._serializationContext()` function, which is labeled as "only public to allow for testing". But I could not find a different way to get or construct such an object.
- For implementation of the new ParserBase functions like `getString()`, I followed the implementation of jackson-databind's TreeTraversingParser - but I don't know if this code path is exercised or what it's used for. 

Sorry for the large diff, I hope the commits are good and it's straight forward to review 😸 